### PR TITLE
Fix missing Mongo default DB handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ BOT_TOKEN=your_bot_token
 
 # Database
 MONGO_URI=mongodb://localhost:27017/oxeign
+MONGO_DB_NAME=oxeign
 
 # Bot control
 OWNER_ID=123456789

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Oxeign Telegram Guard is a modular security bot built with **Pyrogram**. It keep
    ```bash
    pip install -r requirements.txt
    ```
-3. Copy `.env.example` to `.env` and fill in your API keys and database URI.
+3. Copy `.env.example` to `.env` and fill in your API keys and database URI. If
+   your MongoDB URI does not contain a database name, set `MONGO_DB_NAME` as
+   well.
 4. Run the bot:
    ```bash
    python -m oxeign.main

--- a/oxeign/swagger/__init__.py
+++ b/oxeign/swagger/__init__.py
@@ -1,5 +1,12 @@
 from motor.motor_asyncio import AsyncIOMotorClient
 from oxeign.config import MONGO_URI
+import os
+from pymongo.errors import ConfigurationError
+
+DEFAULT_DB_NAME = os.getenv("MONGO_DB_NAME", "oxeign")
 
 client = AsyncIOMotorClient(MONGO_URI)
-db = client.get_default_database()
+try:
+    db = client.get_default_database()
+except ConfigurationError:
+    db = client[DEFAULT_DB_NAME]


### PR DESCRIPTION
## Summary
- handle missing default database name in Mongo client
- document optional `MONGO_DB_NAME` env in README
- add `MONGO_DB_NAME` to `.env.example`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6865a28cbbe8832990981d19929a76dd