### PR TITLE
Enhance bot UI and moderation

### DIFF
--- a/oxeign/botsyard/admin.py
+++ b/oxeign/botsyard/admin.py
@@ -2,7 +2,8 @@ from pyrogram import Client, filters
 from pyrogram.types import ChatPermissions, InlineKeyboardMarkup, InlineKeyboardButton
 from pyrogram.handlers import MessageHandler, CallbackQueryHandler
 from oxeign.utils.filters import admin_filter
-from oxeign.utils.perms import is_admin
+from oxeign.utils.perms import is_admin, is_sudo
+from oxeign.utils.cleaner import auto_delete
 from oxeign.swagger.warns import add_warn, clear_warns
 from oxeign.utils.logger import log_to_channel
 
@@ -14,16 +15,18 @@ async def mute(client: Client, message):
     if await is_admin(client, message.chat.id, user_id):
         return await message.reply("Cannot mute an admin")
     await client.restrict_chat_member(message.chat.id, user_id, ChatPermissions())
-    await message.reply("User muted")
+    reply = await message.reply("User muted")
     await log_to_channel(client, f"Muted {user_id} in {message.chat.id}")
+    client.loop.create_task(auto_delete(client, message, reply))
 
 async def unmute(client: Client, message):
     if not message.reply_to_message:
         return await message.reply("Reply to a user to unmute")
     user_id = message.reply_to_message.from_user.id
     await client.unban_chat_member(message.chat.id, user_id, only_if_banned=False)
-    await message.reply("User unmuted")
+    reply = await message.reply("User unmuted")
     await log_to_channel(client, f"Unmuted {user_id} in {message.chat.id}")
+    client.loop.create_task(auto_delete(client, message, reply))
 
 async def ban(client: Client, message):
     if not message.reply_to_message:
@@ -32,16 +35,90 @@ async def ban(client: Client, message):
     if await is_admin(client, message.chat.id, user_id):
         return await message.reply("Cannot ban an admin")
     await client.ban_chat_member(message.chat.id, user_id)
-    await message.reply("User banned")
+    reply = await message.reply("User banned")
     await log_to_channel(client, f"Banned {user_id} in {message.chat.id}")
+    client.loop.create_task(auto_delete(client, message, reply))
 
 async def unban(client: Client, message):
     if len(message.command) < 2 and not message.reply_to_message:
         return await message.reply("Usage: reply or /unban user_id")
     user_id = int(message.command[1]) if len(message.command) > 1 else message.reply_to_message.from_user.id
     await client.unban_chat_member(message.chat.id, user_id)
-    await message.reply("User unbanned")
+    reply = await message.reply("User unbanned")
     await log_to_channel(client, f"Unbanned {user_id} in {message.chat.id}")
+    client.loop.create_task(auto_delete(client, message, reply))
+
+async def gban(client: Client, message):
+    if not await is_sudo(message.from_user.id):
+        return
+    if not message.reply_to_message:
+        return await message.reply("Reply to a user to gban")
+    user_id = message.reply_to_message.from_user.id
+    count = 0
+    async for dialog in client.get_dialogs():
+        if dialog.chat.type in ("supergroup", "group"):
+            try:
+                await client.ban_chat_member(dialog.chat.id, user_id)
+                count += 1
+            except Exception:
+                continue
+    reply = await message.reply(f"Globally banned in {count} chats")
+    await log_to_channel(client, f"Gban {user_id} by {message.from_user.id} ({count})")
+    client.loop.create_task(auto_delete(client, message, reply))
+
+async def gunban(client: Client, message):
+    if not await is_sudo(message.from_user.id):
+        return
+    if not message.reply_to_message:
+        return await message.reply("Reply to a user to gunban")
+    user_id = message.reply_to_message.from_user.id
+    count = 0
+    async for dialog in client.get_dialogs():
+        if dialog.chat.type in ("supergroup", "group"):
+            try:
+                await client.unban_chat_member(dialog.chat.id, user_id)
+                count += 1
+            except Exception:
+                continue
+    reply = await message.reply(f"Globally unbanned in {count} chats")
+    await log_to_channel(client, f"Gunban {user_id} by {message.from_user.id} ({count})")
+    client.loop.create_task(auto_delete(client, message, reply))
+
+async def gmute(client: Client, message):
+    if not await is_sudo(message.from_user.id):
+        return
+    if not message.reply_to_message:
+        return await message.reply("Reply to a user to gmute")
+    user_id = message.reply_to_message.from_user.id
+    count = 0
+    async for dialog in client.get_dialogs():
+        if dialog.chat.type in ("supergroup", "group"):
+            try:
+                await client.restrict_chat_member(dialog.chat.id, user_id, ChatPermissions())
+                count += 1
+            except Exception:
+                continue
+    reply = await message.reply(f"Globally muted in {count} chats")
+    await log_to_channel(client, f"Gmute {user_id} by {message.from_user.id} ({count})")
+    client.loop.create_task(auto_delete(client, message, reply))
+
+async def gunmute(client: Client, message):
+    if not await is_sudo(message.from_user.id):
+        return
+    if not message.reply_to_message:
+        return await message.reply("Reply to a user to gunmute")
+    user_id = message.reply_to_message.from_user.id
+    count = 0
+    async for dialog in client.get_dialogs():
+        if dialog.chat.type in ("supergroup", "group"):
+            try:
+                await client.unban_chat_member(dialog.chat.id, user_id, only_if_banned=False)
+                count += 1
+            except Exception:
+                continue
+    reply = await message.reply(f"Globally unmuted in {count} chats")
+    await log_to_channel(client, f"Gunmute {user_id} by {message.from_user.id} ({count})")
+    client.loop.create_task(auto_delete(client, message, reply))
 
 async def kick(client: Client, message):
     if not message.reply_to_message:
@@ -51,8 +128,9 @@ async def kick(client: Client, message):
         return await message.reply("Cannot kick an admin")
     await client.ban_chat_member(message.chat.id, user_id)
     await client.unban_chat_member(message.chat.id, user_id)
-    await message.reply("User kicked")
+    reply = await message.reply("User kicked")
     await log_to_channel(client, f"Kicked {user_id} in {message.chat.id}")
+    client.loop.create_task(auto_delete(client, message, reply))
 
 
 async def warn(client: Client, message):
@@ -65,8 +143,9 @@ async def warn(client: Client, message):
     buttons = InlineKeyboardMarkup(
         [[InlineKeyboardButton("Clear Warns", callback_data=f"clearwarn:{user_id}")]]
     )
-    await message.reply(f"User warned. Total warns: {count}", reply_markup=buttons)
+    reply = await message.reply(f"User warned. Total warns: {count}", reply_markup=buttons)
     await log_to_channel(client, f"Warned {user_id} ({count}) in {message.chat.id}")
+    client.loop.create_task(auto_delete(client, message, reply))
 
 
 async def clear_warn_callback(client: Client, callback_query):
@@ -76,6 +155,7 @@ async def clear_warn_callback(client: Client, callback_query):
     await callback_query.answer("Warns cleared", show_alert=True)
     await callback_query.message.edit("Warns cleared")
     await log_to_channel(client, f"Cleared warns for {user_id} in {callback_query.message.chat.id}")
+    client.loop.create_task(auto_delete(client, callback_query.message))
 
 
 def register(app: Client):
@@ -86,3 +166,7 @@ def register(app: Client):
     app.add_handler(MessageHandler(kick, filters.command("kick") & admin_filter))
     app.add_handler(MessageHandler(warn, filters.command("warn") & admin_filter))
     app.add_handler(CallbackQueryHandler(clear_warn_callback, filters.regex("^clearwarn:")))
+    app.add_handler(MessageHandler(gban, filters.command("gban")))
+    app.add_handler(MessageHandler(gunban, filters.command("gunban")))
+    app.add_handler(MessageHandler(gmute, filters.command("gmute")))
+    app.add_handler(MessageHandler(gunmute, filters.command("gunmute")))

--- a/oxeign/botsyard/bot.py
+++ b/oxeign/botsyard/bot.py
@@ -1,19 +1,57 @@
 from pyrogram import Client, filters
-from pyrogram.handlers import MessageHandler
-from oxeign.config import START_IMAGE
+from pyrogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+from pyrogram.handlers import MessageHandler, CallbackQueryHandler
+from oxeign.config import START_IMAGE, BOT_NAME
+from oxeign.utils.cleaner import auto_delete
 
 async def start(client: Client, message):
-    text = "I am alive!"
-    await message.reply_photo(START_IMAGE, caption=text) if START_IMAGE else await message.reply(text)
+    text = f"✨ Welcome to <b>{BOT_NAME}</b>!" \
+        "\nYour personal guardian at your service."
+    buttons = InlineKeyboardMarkup(
+        [
+            [InlineKeyboardButton("📖 Help", callback_data="help")],
+            [InlineKeyboardButton("💬 Support", url="https://t.me/botsyard")],
+        ]
+    )
+    reply = (
+        await message.reply_photo(START_IMAGE, caption=text, reply_markup=buttons, parse_mode="html")
+        if START_IMAGE
+        else await message.reply(text, reply_markup=buttons, parse_mode="html")
+    )
+    client.loop.create_task(auto_delete(client, message, reply))
 
 async def help_cmd(client: Client, message):
     help_text = (
-        "Available commands: /approve, /disapprove, /setlongmode, /setlonglimit, "
-        "/biolink, /broadcast, /mute, /unmute, /ban, /unban, /kick, /warn, /addsudo, /rmsudo"
+        "<b>Master Guardian Commands</b>\n"
+        "• /approve - Allow a user\n"
+        "• /disapprove - Revoke approval\n"
+        "• /setlongmode &lt;mode&gt;\n"
+        "• /setlonglimit &lt;num&gt;\n"
+        "• /biolink on|off\n"
+        "• /broadcast &lt;text&gt;\n"
+        "• /mute /unmute\n"
+        "• /ban /unban /kick\n"
+        "• /warn - Issue warn\n"
+        "• /addsudo /rmsudo\n"
+        "• /gban /gunban /gmute /gunmute (sudo)"
     )
-    await message.reply(help_text)
+    buttons = InlineKeyboardMarkup(
+        [
+            [InlineKeyboardButton("➕ Add to Chat", url=f"https://t.me/{BOT_NAME}?startgroup=true")],
+            [InlineKeyboardButton("💬 Support", url="https://t.me/botsyard")],
+        ]
+    )
+    reply = await message.reply(help_text, reply_markup=buttons, parse_mode="html")
+    client.loop.create_task(auto_delete(client, message, reply))
+
+async def help_callback(client: Client, callback_query):
+    await callback_query.answer()
+    await callback_query.message.delete()
+    m = await callback_query.message.reply("/help")
+    await help_cmd(client, m)
 
 
 def register(app: Client):
     app.add_handler(MessageHandler(start, filters.command("start")))
     app.add_handler(MessageHandler(help_cmd, filters.command("help")))
+    app.add_handler(CallbackQueryHandler(help_callback, filters.regex("^help$")))

--- a/oxeign/botsyard/filters.py
+++ b/oxeign/botsyard/filters.py
@@ -54,10 +54,11 @@ async def check_message(client: Client, message):
 
     if await is_biomode(message.chat.id):
         try:
-            user = await client.get_users(message.from_user.id)
+            chat = await client.get_chat(message.from_user.id)
+            bio = chat.bio or ""
         except Exception:
-            return
-        if user.bio and LINK_RE.search(user.bio.lower()):
+            bio = ""
+        if bio and LINK_RE.search(bio.lower()):
             await message.delete()
             await log_to_channel(client, f"{BOT_NAME}: Deleted message due to bio link from {message.from_user.mention}")
             return

--- a/oxeign/utils/cleaner.py
+++ b/oxeign/utils/cleaner.py
@@ -1,0 +1,9 @@
+import asyncio
+
+async def auto_delete(client, command_msg, reply_msg=None, delay=10):
+    await asyncio.sleep(delay)
+    for msg in filter(None, [command_msg, reply_msg]):
+        try:
+            await msg.delete()
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- add auto-delete helper
- modernize /start and /help commands with buttons
- support global ban/mute actions for sudo
- auto delete admin command messages
- fix bio link detection

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6865aa774e448329a95684da1ef724c1