### PR TITLE
Add premium moderation features

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Oxeign Telegram Guard is a modular security bot built with **Pyrogram**. It keep
 - Moderation tools: `/mute`, `/unmute`, `/ban`, `/unban`, `/kick`, `/warn`
 - Sudo management: `/addsudo`, `/rmsudo`
 - Broadcast messages: `/broadcast <text>`
+- Auto delete timer: `/setautodelete <seconds>`
+- Blacklist management: `/blacklist add|remove|list`
+- Custom welcome messages: `/setwelcome <text>`
 - View chat configuration: `/getconfig`
 
 ## Setup
@@ -38,4 +41,4 @@ pip install detoxify torch
 
 ## Credits
 
-Developed by [@Oxeign](https://t.me/Oxeign) with help from [@MajorGameApp](https://t.me/MajorGameApp).
+Developed by [@Oxeign](https://t.me/Oxeign). Need help? Visit [@Botsyard](https://t.me/Botsyard).

--- a/oxeign/botsyard/__init__.py
+++ b/oxeign/botsyard/__init__.py
@@ -1,9 +1,33 @@
 from pyrogram import Client
 
-from . import bot, admin, broadcast, biomode, approval, longmode, sudo, filters as guard_filters
+from . import (
+    bot,
+    admin,
+    broadcast,
+    biomode,
+    approval,
+    longmode,
+    sudo,
+    filters as guard_filters,
+    welcome,
+    blacklist,
+    autodelete,
+)
 
 
 def register_handlers(app: Client):
-    for module in (bot, admin, broadcast, biomode, approval, longmode, sudo, guard_filters):
-        if hasattr(module, 'register'):
+    for module in (
+        bot,
+        admin,
+        broadcast,
+        biomode,
+        approval,
+        longmode,
+        sudo,
+        guard_filters,
+        welcome,
+        blacklist,
+        autodelete,
+    ):
+        if hasattr(module, "register"):
             module.register(app)

--- a/oxeign/botsyard/autodelete.py
+++ b/oxeign/botsyard/autodelete.py
@@ -1,0 +1,36 @@
+from pyrogram import Client, filters
+from pyrogram.handlers import MessageHandler
+from pyrogram.types import Message
+from oxeign.utils.filters import admin_filter
+from oxeign.swagger.autodelete import set_autodelete, get_autodelete
+from oxeign.utils.perms import is_admin
+from oxeign.utils.logger import log_to_channel
+import asyncio
+async def set_autodelete_cmd(client: Client, message: Message):
+    if len(message.command) < 2:
+        return await message.reply("Usage: /setautodelete <seconds>")
+    try:
+        seconds = int(message.command[1])
+    except ValueError:
+        return await message.reply("Seconds must be a number")
+    await set_autodelete(message.chat.id, seconds)
+    await message.reply("✅ Auto delete updated")
+    await log_to_channel(client, f"Auto delete set to {seconds}s in {message.chat.id}")
+
+
+async def auto_delete_handler(client: Client, message: Message):
+    if not message.from_user or await is_admin(client, message.chat.id, message.from_user.id):
+        return
+    seconds = await get_autodelete(message.chat.id)
+    if seconds > 0:
+        await asyncio.sleep(seconds)
+        try:
+            await message.delete()
+        except Exception:
+            pass
+
+
+def register(app: Client):
+    app.add_handler(MessageHandler(set_autodelete_cmd, filters.command("setautodelete") & admin_filter))
+    app.add_handler(MessageHandler(auto_delete_handler, filters.chat_type.groups & ~filters.service))
+

--- a/oxeign/botsyard/blacklist.py
+++ b/oxeign/botsyard/blacklist.py
@@ -1,0 +1,49 @@
+from pyrogram import Client, filters
+from pyrogram.types import Message
+from pyrogram.handlers import MessageHandler
+from oxeign.utils.filters import admin_filter
+from oxeign.swagger.blacklist import add_word, remove_word, list_words
+from oxeign.utils.logger import log_to_channel
+
+
+async def blacklist_cmd(client: Client, message: Message):
+    if len(message.command) < 2:
+        words = await list_words(message.chat.id)
+        text = "\n".join(words) or "No words set"
+        return await message.reply(f"<b>Blacklisted Words</b>\n{text}", parse_mode="html")
+    action = message.command[1].lower()
+    if action == "add" and len(message.command) > 2:
+        word = message.command[2].lower()
+        await add_word(message.chat.id, word)
+        await message.reply("✅ Word added")
+        await log_to_channel(client, f"Added blacklist word '{word}' in {message.chat.id}")
+    elif action in {"remove", "del"} and len(message.command) > 2:
+        word = message.command[2].lower()
+        await remove_word(message.chat.id, word)
+        await message.reply("✅ Word removed")
+        await log_to_channel(client, f"Removed blacklist word '{word}' in {message.chat.id}")
+    elif action == "list":
+        words = await list_words(message.chat.id)
+        text = "\n".join(words) or "No words set"
+        await message.reply(f"<b>Blacklisted Words</b>\n{text}", parse_mode="html")
+    else:
+        await message.reply("Usage: /blacklist [add|remove|list] <word>")
+
+
+async def enforce_blacklist(client: Client, message: Message):
+    if not message.text or message.service or not message.from_user:
+        return
+    words = await list_words(message.chat.id)
+    if not words:
+        return
+    lower = message.text.lower()
+    for word in words:
+        if word in lower:
+            await message.delete()
+            await log_to_channel(client, f"Deleted blacklisted word in {message.chat.id} from {message.from_user.id}")
+            break
+
+
+def register(app: Client):
+    app.add_handler(MessageHandler(blacklist_cmd, filters.command("blacklist") & admin_filter))
+    app.add_handler(MessageHandler(enforce_blacklist, filters.chat_type.groups & ~filters.service))

--- a/oxeign/botsyard/bot.py
+++ b/oxeign/botsyard/bot.py
@@ -3,14 +3,27 @@ from pyrogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 from pyrogram.handlers import MessageHandler, CallbackQueryHandler
 from oxeign.config import START_IMAGE, BOT_NAME
 from oxeign.utils.cleaner import auto_delete
+from oxeign.utils.perms import get_role
+from oxeign.utils.logger import log_to_channel
 
 async def start(client: Client, message):
-    text = f"✨ Welcome to <b>{BOT_NAME}</b>!" \
-        "\nYour personal guardian at your service."
+    user = message.from_user
+    role = await get_role(client, None, user.id)
+    full_name = " ".join(filter(None, [user.first_name, user.last_name]))
+    username = f"@{user.username}" if user.username else "N/A"
+    group_count = sum(1 async for d in client.get_dialogs() if d.chat.type in ("supergroup", "group"))
+    text = (
+        f"<b>{full_name}</b>\n"
+        f"ID: <code>{user.id}</code>\n"
+        f"Username: {username}\n"
+        f"Role: <b>{role}</b>\n"
+        f"Groups: {group_count}\n\n"
+        f"Welcome to <b>{BOT_NAME}</b>, your premium moderation assistant."
+    )
     buttons = InlineKeyboardMarkup(
         [
-            [InlineKeyboardButton("📖 Help", callback_data="help")],
-            [InlineKeyboardButton("💬 Support", url="https://t.me/botsyard")],
+            [InlineKeyboardButton("🛠 Commands", callback_data="menu"), InlineKeyboardButton("❓ Help", callback_data="help")],
+            [InlineKeyboardButton("📚 How It Works", url="https://t.me/Botsyard"), InlineKeyboardButton("📣 Support", url="https://t.me/Botsyard")],
         ]
     )
     reply = (
@@ -19,21 +32,18 @@ async def start(client: Client, message):
         else await message.reply(text, reply_markup=buttons, parse_mode="html")
     )
     client.loop.create_task(auto_delete(client, message, reply))
+    await log_to_channel(client, f"/start by {user.id}")
 
 async def help_cmd(client: Client, message):
     help_text = (
-        "<b>Master Guardian Commands</b>\n"
-        "• /approve - Allow a user\n"
-        "• /disapprove - Revoke approval\n"
-        "• /setlongmode &lt;mode&gt;\n"
-        "• /setlonglimit &lt;num&gt;\n"
-        "• /biolink on|off\n"
-        "• /broadcast &lt;text&gt;\n"
-        "• /mute /unmute\n"
-        "• /ban /unban /kick\n"
-        "• /warn - Issue warn\n"
+        "<b>Oxeign Guard Commands</b>\n"
+        "• /menu - Command list\n"
+        "• /ban /unban /mute /unmute\n"
         "• /addsudo /rmsudo\n"
-        "• /gban /gunban /gmute /gunmute (sudo)"
+        "• /blacklist add|remove|list\n"
+        "• /setautodelete &lt;sec&gt;\n"
+        "• /setwelcome &lt;text&gt;\n"
+        "• /broadcast &lt;text&gt;\n"
     )
     buttons = InlineKeyboardMarkup(
         [
@@ -44,14 +54,35 @@ async def help_cmd(client: Client, message):
     reply = await message.reply(help_text, reply_markup=buttons, parse_mode="html")
     client.loop.create_task(auto_delete(client, message, reply))
 
+async def menu_cmd(client: Client, message):
+    text = (
+        "<b>Command Menu</b>\n"
+        "/ban /unban /mute /unmute\n"
+        "/addsudo /rmsudo\n"
+        "/blacklist add|remove|list\n"
+        "/setautodelete <sec>\n"
+        "/setwelcome <text>\n"
+        "/broadcast <text>"
+    )
+    reply = await message.reply(text, parse_mode="html")
+    client.loop.create_task(auto_delete(client, message, reply))
+
 async def help_callback(client: Client, callback_query):
     await callback_query.answer()
     await callback_query.message.delete()
     m = await callback_query.message.reply("/help")
     await help_cmd(client, m)
 
+async def menu_callback(client: Client, callback_query):
+    await callback_query.answer()
+    await callback_query.message.delete()
+    m = await callback_query.message.reply("/menu")
+    await menu_cmd(client, m)
+
 
 def register(app: Client):
     app.add_handler(MessageHandler(start, filters.command("start")))
     app.add_handler(MessageHandler(help_cmd, filters.command("help")))
+    app.add_handler(MessageHandler(menu_cmd, filters.command("menu")))
     app.add_handler(CallbackQueryHandler(help_callback, filters.regex("^help$")))
+    app.add_handler(CallbackQueryHandler(menu_callback, filters.regex("^menu$")))

--- a/oxeign/botsyard/broadcast.py
+++ b/oxeign/botsyard/broadcast.py
@@ -1,10 +1,12 @@
 from pyrogram import Client, filters
 from pyrogram.handlers import MessageHandler
-from oxeign.utils.filters import admin_filter
+from oxeign.utils.perms import is_sudo
 from oxeign.utils.logger import log_to_channel
 
 
 async def broadcast(client: Client, message):
+    if not await is_sudo(message.from_user.id):
+        return
     if len(message.command) < 2 and not message.reply_to_message:
         return await message.reply("Usage: /broadcast <text> or reply to a message")
     text = message.text.split(None, 1)[1] if len(message.command) > 1 else message.reply_to_message.text
@@ -20,4 +22,4 @@ async def broadcast(client: Client, message):
 
 
 def register(app: Client):
-    app.add_handler(MessageHandler(broadcast, filters.command("broadcast") & admin_filter))
+    app.add_handler(MessageHandler(broadcast, filters.command("broadcast")))

--- a/oxeign/botsyard/welcome.py
+++ b/oxeign/botsyard/welcome.py
@@ -1,0 +1,32 @@
+from pyrogram import Client, filters
+from pyrogram.types import Message, InlineKeyboardMarkup, InlineKeyboardButton
+from pyrogram.handlers import MessageHandler
+from oxeign.swagger.welcome import set_welcome, get_welcome
+from oxeign.utils.filters import admin_filter
+from oxeign.utils.logger import log_to_channel
+
+
+async def set_welcome_cmd(client: Client, message: Message):
+    if len(message.command) < 2:
+        return await message.reply("Usage: /setwelcome <text>")
+    text = message.text.split(None, 1)[1]
+    await set_welcome(message.chat.id, text)
+    await message.reply("✅ Welcome message saved")
+    await log_to_channel(client, f"Set welcome in {message.chat.id}")
+
+
+async def new_member(client: Client, message: Message):
+    welcome = await get_welcome(message.chat.id)
+    buttons = InlineKeyboardMarkup(
+        [[InlineKeyboardButton("🛠 Commands", callback_data="help"), InlineKeyboardButton("📣 Support", url="https://t.me/Botsyard")]]
+    )
+    for user in message.new_chat_members:
+        text = welcome.format(mention=user.mention)
+        await message.reply(text, reply_markup=buttons if user.is_self else None)
+        if user.is_self:
+            await log_to_channel(client, f"Bot added to {message.chat.id}")
+
+
+def register(app: Client):
+    app.add_handler(MessageHandler(set_welcome_cmd, filters.command("setwelcome") & admin_filter))
+    app.add_handler(MessageHandler(new_member, filters.chat_type.groups & filters.new_chat_members))

--- a/oxeign/swagger/autodelete.py
+++ b/oxeign/swagger/autodelete.py
@@ -1,0 +1,10 @@
+from . import db
+
+autodelete_col = db['autodelete']
+
+async def set_autodelete(chat_id: int, seconds: int):
+    await autodelete_col.update_one({'chat_id': chat_id}, {'$set': {'seconds': seconds}}, upsert=True)
+
+async def get_autodelete(chat_id: int) -> int:
+    data = await autodelete_col.find_one({'chat_id': chat_id})
+    return int(data.get('seconds', 0)) if data else 0

--- a/oxeign/swagger/blacklist.py
+++ b/oxeign/swagger/blacklist.py
@@ -1,0 +1,25 @@
+from . import db
+import os
+
+blacklist_col = db['blacklists']
+BASE_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), '..', 'blacklists')
+os.makedirs(BASE_DIR, exist_ok=True)
+
+async def add_word(chat_id: int, word: str):
+    await blacklist_col.update_one({'chat_id': chat_id}, {'$addToSet': {'words': word.lower()}}, upsert=True)
+    await sync_words(chat_id)
+
+async def remove_word(chat_id: int, word: str):
+    await blacklist_col.update_one({'chat_id': chat_id}, {'$pull': {'words': word.lower()}}, upsert=True)
+    await sync_words(chat_id)
+
+async def list_words(chat_id: int) -> list:
+    data = await blacklist_col.find_one({'chat_id': chat_id})
+    return data.get('words', []) if data else []
+
+async def sync_words(chat_id: int) -> str:
+    words = await list_words(chat_id)
+    path = os.path.join(BASE_DIR, f"{chat_id}.txt")
+    with open(path, 'w') as f:
+        f.write('\n'.join(words))
+    return path

--- a/oxeign/swagger/welcome.py
+++ b/oxeign/swagger/welcome.py
@@ -1,0 +1,12 @@
+from . import db
+
+welcome_col = db['welcome']
+
+DEFAULT_WELCOME = 'Welcome {mention}!'
+
+async def set_welcome(chat_id: int, text: str):
+    await welcome_col.update_one({'chat_id': chat_id}, {'$set': {'text': text}}, upsert=True)
+
+async def get_welcome(chat_id: int) -> str:
+    data = await welcome_col.find_one({'chat_id': chat_id})
+    return data.get('text', DEFAULT_WELCOME)

--- a/oxeign/utils/perms.py
+++ b/oxeign/utils/perms.py
@@ -15,3 +15,19 @@ async def is_admin(client: Client, chat_id: int, user_id: int) -> bool:
     except Exception:
         return False
     return member.status in (ChatMemberStatus.OWNER, ChatMemberStatus.ADMINISTRATOR)
+
+
+async def get_role(client: Client, chat_id: int | None, user_id: int) -> str:
+    if user_id == OWNER_ID:
+        return "owner"
+    sudos = await get_sudos()
+    if user_id in sudos:
+        return "sudo"
+    if chat_id:
+        try:
+            member = await client.get_chat_member(chat_id, user_id)
+            if member.status in (ChatMemberStatus.OWNER, ChatMemberStatus.ADMINISTRATOR):
+                return "admin"
+        except Exception:
+            pass
+    return "user"


### PR DESCRIPTION
## Summary
- enrich `/start` with a profile card and premium buttons
- add command menu and improved help output
- implement blacklist management and auto delete timer
- support custom welcome messages
- fetch roles dynamically via new `get_role`
- update README with new commands and credits

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6865b0d96a6c83299d354661453a18aa