### PR TITLE
Fix bot error handling

### DIFF
--- a/oxeign/botsyard/blacklist.py
+++ b/oxeign/botsyard/blacklist.py
@@ -10,7 +10,7 @@ async def blacklist_cmd(client: Client, message: Message):
     if len(message.command) < 2:
         words = await list_words(message.chat.id)
         text = "\n".join(words) or "No words set"
-        return await message.reply(f"<b>Blacklisted Words</b>\n{text}", parse_mode="html")
+        return await message.reply(f"<b>Blacklisted Words</b>\n{text}", parse_mode="HTML")
     action = message.command[1].lower()
     if action == "add" and len(message.command) > 2:
         word = message.command[2].lower()
@@ -25,7 +25,7 @@ async def blacklist_cmd(client: Client, message: Message):
     elif action == "list":
         words = await list_words(message.chat.id)
         text = "\n".join(words) or "No words set"
-        await message.reply(f"<b>Blacklisted Words</b>\n{text}", parse_mode="html")
+        await message.reply(f"<b>Blacklisted Words</b>\n{text}", parse_mode="HTML")
     else:
         await message.reply("Usage: /blacklist [add|remove|list] <word>")
 

--- a/oxeign/botsyard/bot.py
+++ b/oxeign/botsyard/bot.py
@@ -11,7 +11,10 @@ async def start(client: Client, message):
     role = await get_role(client, None, user.id)
     full_name = " ".join(filter(None, [user.first_name, user.last_name]))
     username = f"@{user.username}" if user.username else "N/A"
-    group_count = sum(1 async for d in client.get_dialogs() if d.chat.type in ("supergroup", "group"))
+    group_count = 0
+    async for d in client.get_dialogs():
+        if d.chat.type in ("supergroup", "group"):
+            group_count += 1
     text = (
         f"<b>{full_name}</b>\n"
         f"ID: <code>{user.id}</code>\n"
@@ -27,9 +30,9 @@ async def start(client: Client, message):
         ]
     )
     reply = (
-        await message.reply_photo(START_IMAGE, caption=text, reply_markup=buttons, parse_mode="html")
+        await message.reply_photo(START_IMAGE, caption=text, reply_markup=buttons, parse_mode="HTML")
         if START_IMAGE
-        else await message.reply(text, reply_markup=buttons, parse_mode="html")
+        else await message.reply(text, reply_markup=buttons, parse_mode="HTML")
     )
     client.loop.create_task(auto_delete(client, message, reply))
     await log_to_channel(client, f"/start by {user.id}")
@@ -51,7 +54,7 @@ async def help_cmd(client: Client, message):
             [InlineKeyboardButton("💬 Support", url="https://t.me/botsyard")],
         ]
     )
-    reply = await message.reply(help_text, reply_markup=buttons, parse_mode="html")
+    reply = await message.reply(help_text, reply_markup=buttons, parse_mode="HTML")
     client.loop.create_task(auto_delete(client, message, reply))
 
 async def menu_cmd(client: Client, message):
@@ -64,7 +67,7 @@ async def menu_cmd(client: Client, message):
         "/setwelcome <text>\n"
         "/broadcast <text>"
     )
-    reply = await message.reply(text, parse_mode="html")
+    reply = await message.reply(text, parse_mode="HTML")
     client.loop.create_task(auto_delete(client, message, reply))
 
 async def help_callback(client: Client, callback_query):


### PR DESCRIPTION
## Summary
- iterate over dialogs using `async for` so the count works
- update parse mode constants for Pyrogram 2

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6865b48f3ea08329a6a47c438b5f4ab1