### PR TITLE
Improve bot menus and add status

### DIFF
--- a/oxeign/botsyard/__init__.py
+++ b/oxeign/botsyard/__init__.py
@@ -13,6 +13,7 @@ from . import (
     welcome,
     blacklist,
     autodelete,
+    status,
 )
 
 
@@ -30,6 +31,7 @@ def register_handlers(app: Client):
         welcome,
         blacklist,
         autodelete,
+        status,
     ):
         if hasattr(module, "register"):
             module.register(app)

--- a/oxeign/botsyard/bot.py
+++ b/oxeign/botsyard/bot.py
@@ -7,6 +7,7 @@ from oxeign.utils.cleaner import auto_delete
 from oxeign.utils.perms import get_role
 from oxeign.utils.logger import log_to_channel
 from oxeign.swagger.groups import add_group, get_groups
+from datetime import datetime
 
 async def start(client: Client, message):
     user = message.from_user
@@ -15,74 +16,103 @@ async def start(client: Client, message):
     username = f"@{user.username}" if user.username else "N/A"
     groups = await get_groups()
     group_count = len(groups)
+
     if message.chat.type in ("supergroup", "group"):
         await add_group(message.chat.id)
+
     text = (
-        f"<b>{full_name}</b>\n"
+        f"<b>{BOT_NAME}</b> welcomes you, {user.mention()}!\n"
+        f"Role: <b>{role.title()}</b>\n"
         f"ID: <code>{user.id}</code>\n"
         f"Username: {username}\n"
-        f"Role: <b>{role}</b>\n"
-        f"Groups: {group_count}\n\n"
-        f"Welcome to <b>{BOT_NAME}</b>, your premium moderation assistant."
+        f"Groups served: <b>{group_count}</b>"
     )
+
+    rows = [
+        [InlineKeyboardButton("❓ Help", callback_data="help"), InlineKeyboardButton("🛠 Commands", callback_data="menu")],
+        [InlineKeyboardButton("📣 Support", url="https://t.me/Botsyard"), InlineKeyboardButton("✖️ Close", callback_data="close")],
+    ]
+    buttons = InlineKeyboardMarkup(rows)
+
+    if START_IMAGE:
+        reply = await message.reply_photo(START_IMAGE, caption=text, reply_markup=buttons, parse_mode=ParseMode.HTML)
+    else:
+        reply = await message.reply(text, reply_markup=buttons, parse_mode=ParseMode.HTML)
+
+    if message.chat.type != "private":
+        client.loop.create_task(auto_delete(client, message, reply))
+
+    log_text = (
+        f"#START\n"
+        f"Name: {full_name}\n"
+        f"ID: {user.id}\n"
+        f"Username: {username}\n"
+        f"Link: {user.mention('link')}\n"
+        f"Timestamp: {datetime.utcnow().isoformat()}\n"
+    )
+    await log_to_channel(client, log_text)
+
+def help_content():
+    text = "<b>Need assistance?</b> Use the buttons below to navigate."
     buttons = InlineKeyboardMarkup(
         [
-            [InlineKeyboardButton("🛠 Commands", callback_data="menu"), InlineKeyboardButton("❓ Help", callback_data="help")],
-            [InlineKeyboardButton("📚 How It Works", url="https://t.me/Botsyard"), InlineKeyboardButton("📣 Support", url="https://t.me/Botsyard")],
+            [InlineKeyboardButton("🛠 Commands", callback_data="menu")],
+            [InlineKeyboardButton("💬 Support", url="https://t.me/Botsyard"), InlineKeyboardButton("✖️ Close", callback_data="close")],
         ]
     )
-    reply = (
-        await message.reply_photo(START_IMAGE, caption=text, reply_markup=buttons, parse_mode=ParseMode.HTML)
-        if START_IMAGE
-        else await message.reply(text, reply_markup=buttons, parse_mode=ParseMode.HTML)
-    )
-    client.loop.create_task(auto_delete(client, message, reply))
-    await log_to_channel(client, f"/start by {user.id}")
+    return text, buttons
+
 
 async def help_cmd(client: Client, message):
-    help_text = (
-        "<b>Oxeign Guard Commands</b>\n"
-        "• /menu - Command list\n"
-        "• /ban /unban /mute /unmute\n"
-        "• /addsudo /rmsudo\n"
-        "• /blacklist add|remove|list\n"
-        "• /setautodelete &lt;sec&gt;\n"
-        "• /setwelcome &lt;text&gt;\n"
-        "• /broadcast &lt;text&gt;\n"
-    )
-    buttons = InlineKeyboardMarkup(
-        [
-            [InlineKeyboardButton("➕ Add to Chat", url=f"https://t.me/{BOT_NAME}?startgroup=true")],
-            [InlineKeyboardButton("💬 Support", url="https://t.me/botsyard")],
-        ]
-    )
-    reply = await message.reply(help_text, reply_markup=buttons, parse_mode=ParseMode.HTML)
-    client.loop.create_task(auto_delete(client, message, reply))
+    text, buttons = help_content()
+    reply = await message.reply(text, reply_markup=buttons, parse_mode=ParseMode.HTML)
+    if message.chat.type != "private":
+        client.loop.create_task(auto_delete(client, message, reply))
 
-async def menu_cmd(client: Client, message):
-    text = (
-        "<b>Command Menu</b>\n"
-        "/ban /unban /mute /unmute\n"
-        "/addsudo /rmsudo\n"
-        "/blacklist add|remove|list\n"
-        "/setautodelete <sec>\n"
-        "/setwelcome <text>\n"
-        "/broadcast <text>"
-    )
-    reply = await message.reply(text, parse_mode=ParseMode.HTML)
-    client.loop.create_task(auto_delete(client, message, reply))
+async def menu_cmd(client: Client, message, user=None):
+    user = user or message.from_user
+    role = await get_role(client, message.chat.id if message.chat.type != "private" else None, user.id)
+
+    user_cmds = ["/help", "/menu"]
+    admin_cmds = [
+        "/ban", "/unban", "/mute", "/unmute", "/kick", "/warn",
+        "/approve", "/disapprove", "/setautodelete", "/setwelcome",
+        "/blacklist", "/biolink", "/setlongmode", "/setlonglimit", "/getconfig",
+    ]
+    sudo_cmds = ["/gban", "/gunban", "/gmute", "/gunmute", "/broadcast"]
+    owner_cmds = ["/addsudo", "/rmsudo"]
+
+    cmds = user_cmds
+    if role in {"admin", "sudo", "owner"}:
+        cmds += admin_cmds
+    if role in {"sudo", "owner"}:
+        cmds += sudo_cmds
+    if role == "owner":
+        cmds += owner_cmds
+
+    box = ["╭── Commands ──╮"]
+    for c in cmds:
+        box.append(f"│ {c}")
+    box.append("╰────────────╯")
+    text = "<pre>" + "\n".join(box) + "</pre>"
+
+    buttons = InlineKeyboardMarkup([[InlineKeyboardButton("✖️ Close", callback_data="close")]])
+    reply = await message.reply(text, reply_markup=buttons, parse_mode=ParseMode.HTML)
+    if message.chat.type != "private":
+        client.loop.create_task(auto_delete(client, message, reply))
 
 async def help_callback(client: Client, callback_query):
     await callback_query.answer()
-    await callback_query.message.delete()
-    m = await callback_query.message.reply("/help")
-    await help_cmd(client, m)
+    text, buttons = help_content()
+    await callback_query.message.edit_text(text, reply_markup=buttons, parse_mode=ParseMode.HTML)
 
 async def menu_callback(client: Client, callback_query):
     await callback_query.answer()
+    await menu_cmd(client, callback_query.message, user=callback_query.from_user)
+
+async def close_callback(client: Client, callback_query):
+    await callback_query.answer()
     await callback_query.message.delete()
-    m = await callback_query.message.reply("/menu")
-    await menu_cmd(client, m)
 
 
 def register(app: Client):
@@ -91,3 +121,4 @@ def register(app: Client):
     app.add_handler(MessageHandler(menu_cmd, filters.command("menu")))
     app.add_handler(CallbackQueryHandler(help_callback, filters.regex("^help$")))
     app.add_handler(CallbackQueryHandler(menu_callback, filters.regex("^menu$")))
+    app.add_handler(CallbackQueryHandler(close_callback, filters.regex("^close$")))

--- a/oxeign/botsyard/status.py
+++ b/oxeign/botsyard/status.py
@@ -1,0 +1,23 @@
+from pyrogram import Client, filters
+from pyrogram.handlers import MessageHandler
+from pyrogram.enums import ParseMode
+from oxeign.utils.perms import get_role
+from oxeign.utils.cleaner import auto_delete
+from oxeign.swagger.groups import get_groups
+
+
+async def status_cmd(client: Client, message):
+    groups = await get_groups()
+    role = await get_role(client, None, message.from_user.id)
+    text = (
+        f"<b>Bot Status</b>\n"
+        f"Chats served: <code>{len(groups)}</code>\n"
+        f"Your role: <b>{role}</b>"
+    )
+    reply = await message.reply(text, parse_mode=ParseMode.HTML)
+    if message.chat.type != "private":
+        client.loop.create_task(auto_delete(client, message, reply))
+
+
+def register(app: Client):
+    app.add_handler(MessageHandler(status_cmd, filters.command("status")))


### PR DESCRIPTION
## Summary
- modernize `/start`, `/help`, and `/menu` with inline buttons
- dynamically show commands by role
- add `/status` command
- register the new status module

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6865bb3ac3548329acf989968d6fc2ad