### PR TITLE
Improve admin features and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Oxeign Telegram Guard is a modular security bot built with **Pyrogram**. It keep
 - Long message control: `/setlongmode`, `/setlonglimit`
 - Bio link filtering: `/biolink on|off`
 - Approval system: `/approve` and `/disapprove`
-- Moderation tools: `/mute`, `/unmute`, `/ban`, `/unban`, `/kick`, `/warn`
+- Moderation tools: `/mute`, `/unmute`, `/ban`, `/unban`, `/kick`, `/warn`, `/removewarn`
 - Sudo management: `/addsudo`, `/rmsudo`
 - Broadcast messages with preview: `/broadcast <text>`
 - Auto delete timer: `/setautodelete <seconds>`

--- a/oxeign/botsyard/admin.py
+++ b/oxeign/botsyard/admin.py
@@ -146,6 +146,16 @@ async def warn(client: Client, message):
     client.loop.create_task(auto_delete(client, message, reply))
 
 
+async def removewarn(client: Client, message):
+    if not message.reply_to_message:
+        return await message.reply("❌ Reply to a user to clear warns")
+    user_id = message.reply_to_message.from_user.id
+    await clear_warns(message.chat.id, user_id)
+    reply = await message.reply("✅ <b>Warns cleared</b>", parse_mode=ParseMode.HTML)
+    await log_to_channel(client, f"Cleared warns for {user_id} in {message.chat.id}")
+    client.loop.create_task(auto_delete(client, message, reply))
+
+
 async def clear_warn_callback(client: Client, callback_query):
     data = callback_query.data.split(":")
     user_id = int(data[1])
@@ -163,6 +173,7 @@ def register(app: Client):
     app.add_handler(MessageHandler(unban, filters.command("unban") & admin_filter))
     app.add_handler(MessageHandler(kick, filters.command("kick") & admin_filter))
     app.add_handler(MessageHandler(warn, filters.command("warn") & admin_filter))
+    app.add_handler(MessageHandler(removewarn, filters.command("removewarn") & admin_filter))
     app.add_handler(CallbackQueryHandler(clear_warn_callback, filters.regex("^clearwarn:")))
     app.add_handler(MessageHandler(gban, filters.command("gban")))
     app.add_handler(MessageHandler(gunban, filters.command("gunban")))

--- a/oxeign/botsyard/welcome.py
+++ b/oxeign/botsyard/welcome.py
@@ -37,17 +37,9 @@ async def new_member(client: Client, message: Message):
     buttons = InlineKeyboardMarkup(rows)
     for user in message.new_chat_members:
         text = welcome.format(mention=user.mention)
-        await message.reply(text, reply_markup=buttons if user.is_self else None)
-        ts = datetime.utcnow().isoformat()
+        await message.reply(text, reply_markup=buttons if user.is_self else None, parse_mode=ParseMode.HTML)
         if user.is_self:
             await log_to_channel(client, f"Bot added to {message.chat.id}")
-        else:
-            log_text = (
-                f"#JOIN\nName: {user.first_name} {user.last_name or ''}\nID: {user.id}\n"
-                f"Username: @{user.username or 'N/A'}\nLink: {user.mention('link')}\n"
-                f"Chat: {message.chat.id}\nTimestamp: {ts}"
-            )
-            await log_to_channel(client, log_text)
 
 async def left_member(client: Client, message: Message):
     if not message.left_chat_member:
@@ -56,12 +48,13 @@ async def left_member(client: Client, message: Message):
     user = message.left_chat_member
     text = goodbye.format(mention=user.mention)
     await message.reply(text, parse_mode=ParseMode.HTML)
-    ts = datetime.utcnow().isoformat()
-    log_text = (
-        f"#LEAVE\nName: {user.first_name} {user.last_name or ''}\nID: {user.id}\n"
-        f"Chat: {message.chat.id}\nTimestamp: {ts}"
-    )
-    await log_to_channel(client, log_text)
+    if user.is_self:
+        ts = datetime.utcnow().isoformat()
+        log_text = (
+            f"#LEAVE\nName: {user.first_name} {user.last_name or ''}\nID: {user.id}\n"
+            f"Chat: {message.chat.id}\nTimestamp: {ts}"
+        )
+        await log_to_channel(client, log_text)
 
 
 def register(app: Client):


### PR DESCRIPTION
## Summary
- log /start usage only in private chats
- add `/removewarn` command for admins
- handle MessageNotModified when editing help messages
- include `/removewarn` in docs and menus
- simplify welcome logs and parse HTML properly

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 -m oxeign.main --help` *(fails: ModuleNotFoundError: No module named 'pyrogram')*

------
https://chatgpt.com/codex/tasks/task_b_6865ca227fa08329881a39bc9ed2c33c