### PR TITLE
Add minimal Telegram guard bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,12 @@
-# Oxeign Telegram Guard
+# Minimal Telegram Guard
 
-Oxeign Telegram Guard is a modular security bot built with **Pyrogram**. It keeps groups clean using a mix of admin tools, approval flows and optional toxicity filters powered by the Detoxify model (if installed). All persistent data is stored in MongoDB.
+A lightweight Telegram bot built with **Pyrogram 2.x** for basic group moderation. The bot focuses on two features only and stores all data in MongoDB.
 
 ## Features
 
-- MongoDB backed storage
-- Owner and sudo system
-- Long message control: `/setlongmode`, `/setlonglimit`
-- Bio link filtering: `/biolink on|off`
-- Approval system: `/approve` and `/disapprove`
-- Moderation tools: `/mute`, `/unmute`, `/ban`, `/unban`, `/kick`, `/warn`, `/removewarn`
-- Sudo management: `/addsudo`, `/rmsudo`
-- Broadcast messages with preview: `/broadcast <text>`
-- Auto delete timer: `/setautodelete <seconds>`
-- Blacklist management: `/blacklist add|remove|list`
-- Custom welcome messages: `/setwelcome <text>`
-- Custom goodbye messages: `/setgoodbye <text>`
-- View chat configuration: `/getconfig`
-- Bulk purge messages: `/purge` (reply to a message)
-- View and manage settings: `/settings`
-- Tag everyone: `/tagall`
-- Toggle Anti-Spam, Flood, Captcha and more via buttons
+- **Bio Link Filter** – blocks users with Telegram links in their bio unless approved
+- **Auto Delete Timer** – automatically deletes all messages after a configured delay
+- Admins manage everything via the `/panel` button menu
 
 ## Setup
 
@@ -29,21 +15,12 @@ Oxeign Telegram Guard is a modular security bot built with **Pyrogram**. It keep
    ```bash
    pip install -r requirements.txt
    ```
-3. Copy `.env.example` to `.env` and fill in your API keys and database URI. If
-   your MongoDB URI does not contain a database name, set `MONGO_DB_NAME` as
-   well.
+3. Copy `.env.example` to `.env` and fill in `API_ID`, `API_HASH`, `BOT_TOKEN` and `MONGO_URI`
 4. Run the bot:
    ```bash
    python -m oxeign.main
    ```
 
-### Optional toxicity filtering
-
-To enable Detoxify based toxicity filtering, install the extra packages:
-```bash
-pip install detoxify torch
-```
-
 ## Credits
 
-Developed by [@Oxeign](https://t.me/Oxeign). Need help? Visit [@Botsyard](https://t.me/Botsyard).
+Based on the original project by [@Oxeign](https://t.me/Oxeign).

--- a/oxeign/main.py
+++ b/oxeign/main.py
@@ -1,6 +1,6 @@
 from pyrogram import Client
 from oxeign.config import API_ID, API_HASH, BOT_TOKEN
-from oxeign.botsyard import register_handlers
+from oxeign.minbot import register_handlers
 from oxeign.utils.logger import get_logger
 
 logger = get_logger(__name__)

--- a/oxeign/minbot/__init__.py
+++ b/oxeign/minbot/__init__.py
@@ -1,0 +1,9 @@
+from pyrogram import Client
+
+from . import start, panel, biofilter, autodelete, grouptrack
+
+
+def register_handlers(app: Client):
+    for module in (start, panel, biofilter, autodelete, grouptrack):
+        if hasattr(module, "register"):
+            module.register(app)

--- a/oxeign/minbot/autodelete.py
+++ b/oxeign/minbot/autodelete.py
@@ -1,0 +1,28 @@
+import asyncio
+from pyrogram import Client, filters
+from pyrogram.handlers import MessageHandler
+from pyrogram.types import Message
+
+from oxeign.swagger.autodelete import get_autodelete
+
+
+async def delete_later(message: Message, delay: int):
+    await asyncio.sleep(delay)
+    try:
+        await message.delete()
+    except Exception:
+        pass
+
+
+async def auto_delete_handler(client: Client, message: Message):
+    if message.chat.type not in ("supergroup", "group"):
+        return
+    if message.from_user and message.from_user.is_self:
+        return
+    delay = await get_autodelete(message.chat.id)
+    if delay > 0:
+        asyncio.create_task(delete_later(message, delay))
+
+
+def register(app: Client):
+    app.add_handler(MessageHandler(auto_delete_handler, filters.group & ~filters.service), group=1)

--- a/oxeign/minbot/biofilter.py
+++ b/oxeign/minbot/biofilter.py
@@ -1,0 +1,67 @@
+import re
+from pyrogram import Client, filters
+from pyrogram.handlers import MessageHandler, CallbackQueryHandler
+from pyrogram.types import InlineKeyboardMarkup, InlineKeyboardButton, Message
+
+from oxeign.swagger.biomode import is_biomode
+from oxeign.swagger.approvals import is_approved, add_approval
+from oxeign.utils.perms import is_admin
+
+LINK_RE = re.compile(r"t\.me|telegram\.me|@")
+
+
+async def check_bio(client: Client, message: Message):
+    if message.chat.type not in ("supergroup", "group"):
+        return
+    if not await is_biomode(message.chat.id):
+        return
+    if not message.from_user:
+        return
+    if await is_admin(client, message.chat.id, message.from_user.id):
+        return
+    if await is_approved(message.chat.id, message.from_user.id):
+        return
+    try:
+        member = await client.get_chat_member(message.chat.id, message.from_user.id)
+        bio = member.bio or ""
+    except Exception:
+        bio = ""
+    if bio and LINK_RE.search(bio.lower()):
+        try:
+            await message.delete()
+        except Exception:
+            pass
+        warn_text = (
+            f"{message.from_user.mention}, remove Telegram links from your bio."
+        )
+        buttons = InlineKeyboardMarkup(
+            [
+                [
+                    InlineKeyboardButton(
+                        "Approve", callback_data=f"approve:{message.from_user.id}"
+                    )
+                ]
+            ]
+        )
+        await client.send_message(message.chat.id, warn_text, reply_markup=buttons)
+        try:
+            await client.send_message(
+                message.from_user.id,
+                "Please remove Telegram links from your bio to chat here.",
+            )
+        except Exception:
+            pass
+
+
+async def approve_callback(client: Client, callback_query):
+    user_id = int(callback_query.data.split(":")[1])
+    if not await is_admin(client, callback_query.message.chat.id, callback_query.from_user.id):
+        return await callback_query.answer("Admins only", show_alert=True)
+    await add_approval(callback_query.message.chat.id, user_id)
+    await callback_query.answer("User approved", show_alert=True)
+    await callback_query.message.edit("User approved")
+
+
+def register(app: Client):
+    app.add_handler(MessageHandler(check_bio, filters.group & ~filters.service))
+    app.add_handler(CallbackQueryHandler(approve_callback, filters.regex("^approve:")))

--- a/oxeign/minbot/grouptrack.py
+++ b/oxeign/minbot/grouptrack.py
@@ -1,0 +1,20 @@
+from pyrogram import Client
+from pyrogram.handlers import ChatMemberUpdatedHandler
+from pyrogram.types import ChatMemberUpdated
+from pyrogram.enums import ChatMemberStatus
+
+from oxeign.utils.logger import log_to_channel
+
+
+async def track_updates(client: Client, update: ChatMemberUpdated):
+    if not update.new_chat_member.user.is_self:
+        return
+    status = update.new_chat_member.status
+    if status in (ChatMemberStatus.MEMBER, ChatMemberStatus.ADMINISTRATOR):
+        await log_to_channel(client, f"#ADDED\nChat: {update.chat.id}")
+    elif status in (ChatMemberStatus.KICKED, ChatMemberStatus.LEFT):
+        await log_to_channel(client, f"#REMOVED\nChat: {update.chat.id}")
+
+
+def register(app: Client):
+    app.add_handler(ChatMemberUpdatedHandler(track_updates))

--- a/oxeign/minbot/panel.py
+++ b/oxeign/minbot/panel.py
@@ -1,0 +1,148 @@
+from typing import Dict, Tuple
+from pyrogram import Client, filters
+from pyrogram.handlers import MessageHandler, CallbackQueryHandler
+from pyrogram.types import InlineKeyboardMarkup, InlineKeyboardButton, Message
+from pyrogram.enums import ParseMode
+
+from oxeign.swagger.biomode import is_biomode, set_biomode
+from oxeign.swagger.autodelete import get_autodelete, set_autodelete
+from oxeign.swagger.approvals import add_approval, remove_approval, approvals_col
+from oxeign.utils.perms import is_admin
+
+pending_actions: Dict[Tuple[int, int], str] = {}
+
+
+async def build_panel(chat_id: int) -> InlineKeyboardMarkup:
+    biomode = await is_biomode(chat_id)
+    autodel = await get_autodelete(chat_id)
+    rows = [
+        [InlineKeyboardButton(
+            f"🛡 Bio Link Filter {'On' if biomode else 'Off'}",
+            callback_data="toggle_biolink",
+        )],
+        [InlineKeyboardButton(
+            f"⏱ Set AutoDelete ({autodel if autodel else 'Off'})",
+            callback_data="autodelete",
+        )],
+        [
+            InlineKeyboardButton("✅ Approve User", callback_data="approve_user"),
+            InlineKeyboardButton("❌ Unapprove User", callback_data="unapprove_user"),
+        ],
+        [InlineKeyboardButton("📋 View Approved", callback_data="view_approved")],
+        [InlineKeyboardButton("Close", callback_data="close")],
+    ]
+    return InlineKeyboardMarkup(rows)
+
+
+async def panel_cmd(client: Client, message: Message):
+    if not await is_admin(client, message.chat.id, message.from_user.id):
+        return
+    markup = await build_panel(message.chat.id)
+    await message.reply("**Control Panel**", reply_markup=markup, parse_mode=ParseMode.MARKDOWN)
+
+
+async def toggle_biolink_cb(client: Client, callback_query):
+    if not await is_admin(client, callback_query.message.chat.id, callback_query.from_user.id):
+        return await callback_query.answer("Admins only", show_alert=True)
+    enabled = not await is_biomode(callback_query.message.chat.id)
+    await set_biomode(callback_query.message.chat.id, enabled)
+    await callback_query.answer("Updated", show_alert=False)
+    markup = await build_panel(callback_query.message.chat.id)
+    await callback_query.message.edit("**Control Panel**", reply_markup=markup, parse_mode=ParseMode.MARKDOWN)
+
+
+autodel_menu = InlineKeyboardMarkup([
+    [
+        InlineKeyboardButton("10s", callback_data="set_autodel:10"),
+        InlineKeyboardButton("30s", callback_data="set_autodel:30"),
+        InlineKeyboardButton("1m", callback_data="set_autodel:60"),
+    ],
+    [InlineKeyboardButton("Off", callback_data="set_autodel:0")],
+    [InlineKeyboardButton("⬅️ Back", callback_data="back")],
+])
+
+
+async def autodelete_cb(client: Client, callback_query):
+    if not await is_admin(client, callback_query.message.chat.id, callback_query.from_user.id):
+        return await callback_query.answer("Admins only", show_alert=True)
+    await callback_query.message.edit(
+        "**Select auto-delete delay:**",
+        reply_markup=autodel_menu,
+        parse_mode=ParseMode.MARKDOWN,
+    )
+
+
+async def set_autodel_cb(client: Client, callback_query):
+    if not await is_admin(client, callback_query.message.chat.id, callback_query.from_user.id):
+        return await callback_query.answer("Admins only", show_alert=True)
+    seconds = int(callback_query.data.split(":")[1])
+    await set_autodelete(callback_query.message.chat.id, seconds)
+    await callback_query.answer("Updated", show_alert=False)
+    markup = await build_panel(callback_query.message.chat.id)
+    await callback_query.message.edit("**Control Panel**", reply_markup=markup, parse_mode=ParseMode.MARKDOWN)
+
+
+async def approve_user_cb(client: Client, callback_query):
+    if not await is_admin(client, callback_query.message.chat.id, callback_query.from_user.id):
+        return await callback_query.answer("Admins only", show_alert=True)
+    pending_actions[(callback_query.message.chat.id, callback_query.from_user.id)] = "approve"
+    await callback_query.answer()
+    await callback_query.message.reply("Reply to the user's message to approve.")
+
+
+async def unapprove_user_cb(client: Client, callback_query):
+    if not await is_admin(client, callback_query.message.chat.id, callback_query.from_user.id):
+        return await callback_query.answer("Admins only", show_alert=True)
+    pending_actions[(callback_query.message.chat.id, callback_query.from_user.id)] = "unapprove"
+    await callback_query.answer()
+    await callback_query.message.reply("Reply to the user's message to unapprove.")
+
+
+async def view_approved_cb(client: Client, callback_query):
+    if not await is_admin(client, callback_query.message.chat.id, callback_query.from_user.id):
+        return await callback_query.answer("Admins only", show_alert=True)
+    doc = await approvals_col.find_one({"chat_id": callback_query.message.chat.id})
+    users = doc.get("user_ids", []) if doc else []
+    if users:
+        lines = [f"- [User](tg://user?id={uid})" for uid in users]
+        text = "**Approved Users:**\n" + "\n".join(lines)
+    else:
+        text = "No approved users."
+    markup = InlineKeyboardMarkup([[InlineKeyboardButton("⬅️ Back", callback_data="back")]])
+    await callback_query.message.edit(text, reply_markup=markup, parse_mode=ParseMode.MARKDOWN)
+
+
+async def back_cb(client: Client, callback_query):
+    markup = await build_panel(callback_query.message.chat.id)
+    await callback_query.message.edit("**Control Panel**", reply_markup=markup, parse_mode=ParseMode.MARKDOWN)
+
+
+async def close_cb(client: Client, callback_query):
+    await callback_query.message.delete()
+
+
+async def handle_pending(client: Client, message: Message):
+    key = (message.chat.id, message.from_user.id)
+    if key not in pending_actions or not message.reply_to_message:
+        return
+    action = pending_actions.pop(key)
+    target_id = message.reply_to_message.from_user.id
+    if action == "approve":
+        await add_approval(message.chat.id, target_id)
+        await message.reply(f"Approved [user](tg://user?id={target_id})", parse_mode=ParseMode.MARKDOWN)
+    else:
+        await remove_approval(message.chat.id, target_id)
+        await message.reply(f"Unapproved [user](tg://user?id={target_id})", parse_mode=ParseMode.MARKDOWN)
+
+
+def register(app: Client):
+    app.add_handler(MessageHandler(panel_cmd, filters.command("panel")))
+    app.add_handler(MessageHandler(handle_pending, filters.group), group=2)
+    app.add_handler(CallbackQueryHandler(toggle_biolink_cb, filters.regex("^toggle_biolink$")))
+    app.add_handler(CallbackQueryHandler(autodelete_cb, filters.regex("^autodelete$")))
+    app.add_handler(CallbackQueryHandler(set_autodel_cb, filters.regex("^set_autodel:")))
+    app.add_handler(CallbackQueryHandler(approve_user_cb, filters.regex("^approve_user$")))
+    app.add_handler(CallbackQueryHandler(unapprove_user_cb, filters.regex("^unapprove_user$")))
+    app.add_handler(CallbackQueryHandler(view_approved_cb, filters.regex("^view_approved$")))
+    app.add_handler(CallbackQueryHandler(back_cb, filters.regex("^back$")))
+    app.add_handler(CallbackQueryHandler(close_cb, filters.regex("^close$")))

--- a/oxeign/minbot/start.py
+++ b/oxeign/minbot/start.py
@@ -1,0 +1,27 @@
+from pyrogram import Client, filters
+from pyrogram.handlers import MessageHandler
+from pyrogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+from pyrogram.enums import ParseMode
+
+from oxeign.utils.logger import log_to_channel
+from oxeign.config import BOT_NAME
+
+
+async def start_cmd(client: Client, message):
+    text = (
+        f"**Welcome to {BOT_NAME}!**\n\n"
+        "Use /panel in groups to configure settings."
+    )
+    buttons = InlineKeyboardMarkup(
+        [[InlineKeyboardButton("Support", url="https://t.me/Botsyard")]]
+    )
+    await message.reply(text, reply_markup=buttons, parse_mode=ParseMode.MARKDOWN)
+    if message.chat.type == "private":
+        await log_to_channel(
+            client,
+            f"#START\nUser: {message.from_user.mention} ({message.from_user.id})",
+        )
+
+
+def register(app: Client):
+    app.add_handler(MessageHandler(start_cmd, filters.command("start")))

--- a/oxeign/swagger/approvals.py
+++ b/oxeign/swagger/approvals.py
@@ -11,3 +11,7 @@ async def remove_approval(chat_id: int, user_id: int):
 async def is_approved(chat_id: int, user_id: int) -> bool:
     data = await approvals_col.find_one({"chat_id": chat_id})
     return bool(data and user_id in data.get("user_ids", []))
+
+async def get_approvals(chat_id: int) -> list[int]:
+    data = await approvals_col.find_one({"chat_id": chat_id})
+    return list(data.get("user_ids", [])) if data else []


### PR DESCRIPTION
## Summary
- refactor into a minimal Telegram guard
- implement new start/panel/autodelete/biofilter handlers
- log group joins and leaves
- add helper to fetch approved users
- update README for trimmed features

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6865cffc868c8329853c6505df16fdea