### PR TITLE
Enhance control panel and command triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ A lightweight Telegram bot built with **Pyrogram 2.x** for basic group moderatio
    ```bash
    pip install -r requirements.txt
    ```
-3. Copy `.env.example` to `.env` and fill in `API_ID`, `API_HASH`, `BOT_TOKEN` and `MONGO_URI`
+3. Copy `.env.example` to `.env` and fill in `API_ID`, `API_HASH`, `BOT_TOKEN` and `MONGO_URI`.
+   Optional: `SUPPORT_LINK` and `DEV_LINK` to change panel links.
 4. Run the bot:
    ```bash
    python -m oxeign.main

--- a/oxeign/config/__init__.py
+++ b/oxeign/config/__init__.py
@@ -13,3 +13,5 @@ LOG_CHANNEL_ID = int(os.getenv("LOG_CHANNEL_ID", 0))
 
 # Derived constants
 BOT_NAME = os.getenv('BOT_NAME', 'MasterGuardianBot')
+SUPPORT_LINK = os.getenv('SUPPORT_LINK', 'https://t.me/Botsyard')
+DEV_LINK = os.getenv('DEV_LINK', 'https://t.me/oxeign')

--- a/oxeign/minbot/start.py
+++ b/oxeign/minbot/start.py
@@ -1,21 +1,14 @@
 from pyrogram import Client, filters
 from pyrogram.handlers import MessageHandler
-from pyrogram.types import InlineKeyboardMarkup, InlineKeyboardButton
-from pyrogram.enums import ParseMode
+
 
 from oxeign.utils.logger import log_to_channel
 from oxeign.config import BOT_NAME
+from .panel import send_panel
 
 
 async def start_cmd(client: Client, message):
-    text = (
-        f"**Welcome to {BOT_NAME}!**\n\n"
-        "Use /panel in groups to configure settings."
-    )
-    buttons = InlineKeyboardMarkup(
-        [[InlineKeyboardButton("Support", url="https://t.me/Botsyard")]]
-    )
-    await message.reply(text, reply_markup=buttons, parse_mode=ParseMode.MARKDOWN)
+    await send_panel(client, message)
     if message.chat.type == "private":
         await log_to_channel(
             client,
@@ -25,3 +18,4 @@ async def start_cmd(client: Client, message):
 
 def register(app: Client):
     app.add_handler(MessageHandler(start_cmd, filters.command("start")))
+


### PR DESCRIPTION
## Summary
- extend config with support and developer links
- improve inline control panel with extra rows
- trigger panel with /like command and show panel on /start
- update README for optional env vars

## Testing
- `python -m compileall -q oxeign`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_b_6865d96cb16883298d6830d96edb2aba