### PR TITLE
Fix bio link filter toggle and approvals

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A lightweight Telegram bot built with **Pyrogram 2.x** for basic group moderatio
 
 ## Usage
 
-- Use `/panel` in a group to configure the bot.
+- Use `/panel`, `/start`, `/help` or `/menu` in a group to open the control panel.
 - Admins can `/approve` or `/unapprove` a user by replying to one of their messages.
 
 ## Credits

--- a/oxeign/minbot/approvecmds.py
+++ b/oxeign/minbot/approvecmds.py
@@ -10,7 +10,7 @@ from oxeign.swagger.approvals import add_approval, remove_approval
 async def approve_cmd(client: Client, message: Message):
     if not await is_admin(client, message.chat.id, message.from_user.id):
         return
-    if not message.reply_to_message:
+    if not message.reply_to_message or not message.reply_to_message.from_user:
         await message.reply("Reply to a user's message to approve them.")
         return
     target_id = message.reply_to_message.from_user.id
@@ -24,7 +24,7 @@ async def approve_cmd(client: Client, message: Message):
 async def unapprove_cmd(client: Client, message: Message):
     if not await is_admin(client, message.chat.id, message.from_user.id):
         return
-    if not message.reply_to_message:
+    if not message.reply_to_message or not message.reply_to_message.from_user:
         await message.reply("Reply to a user's message to unapprove them.")
         return
     target_id = message.reply_to_message.from_user.id


### PR DESCRIPTION
## Summary
- simplify main panel layout
- show bio filter status and properly toggle
- ensure approve/unapprove commands validate replied user
- open panel via `/start`, `/help` or `/menu` in groups
- document new commands in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6865eaeff19483299509dd59ae4cfdb4