### PR TITLE
Fix bio filter and control panel layout

### DIFF
--- a/oxeign/minbot/biofilter.py
+++ b/oxeign/minbot/biofilter.py
@@ -7,7 +7,8 @@ from oxeign.swagger.biomode import is_biomode
 from oxeign.swagger.approvals import is_approved, add_approval
 from oxeign.utils.perms import is_admin
 
-LINK_RE = re.compile(r"t\.me|telegram\.me|@")
+# detect telegram usernames/links and general web links
+LINK_RE = re.compile(r"(?:https?://|www\.|t\.me|telegram\.me|@)", re.I)
 
 
 async def check_bio(client: Client, message: Message):
@@ -31,9 +32,7 @@ async def check_bio(client: Client, message: Message):
             await message.delete()
         except Exception:
             pass
-        warn_text = (
-            f"{message.from_user.mention}, remove Telegram links from your bio."
-        )
+        warn_text = f"{message.from_user.mention}, remove Telegram links from your bio."
         buttons = InlineKeyboardMarkup(
             [
                 [
@@ -55,7 +54,9 @@ async def check_bio(client: Client, message: Message):
 
 async def approve_callback(client: Client, callback_query):
     user_id = int(callback_query.data.split(":")[1])
-    if not await is_admin(client, callback_query.message.chat.id, callback_query.from_user.id):
+    if not await is_admin(
+        client, callback_query.message.chat.id, callback_query.from_user.id
+    ):
         return await callback_query.answer("Admins only", show_alert=True)
     await add_approval(callback_query.message.chat.id, user_id)
     await callback_query.answer("User approved", show_alert=True)

--- a/oxeign/minbot/start.py
+++ b/oxeign/minbot/start.py
@@ -8,8 +8,9 @@ from .panel import send_panel
 
 
 async def start_cmd(client: Client, message):
-    if message.chat.type == "private":
-        await send_panel(client, message)
+    private = message.chat.type == "private"
+    await send_panel(client, message, private=private)
+    if private:
         await log_to_channel(
             client,
             f"#START\nUser: {message.from_user.mention} ({message.from_user.id})",
@@ -18,4 +19,3 @@ async def start_cmd(client: Client, message):
 
 def register(app: Client):
     app.add_handler(MessageHandler(start_cmd, filters.command("start")))
-


### PR DESCRIPTION
## Summary
- improve link regex to catch any Telegram or web links
- show full panel for /start in groups and smaller panel in private
- redesign control panel buttons and adjust callbacks

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black --check oxeign/minbot/biofilter.py oxeign/minbot/start.py oxeign/minbot/panel.py`

------
https://chatgpt.com/codex/tasks/task_b_6865ee7f720c8329ba1d86a8e39856a2