### PR TITLE
Improve bio filter and panel layout

### DIFF
--- a/oxeign/minbot/panel.py
+++ b/oxeign/minbot/panel.py
@@ -66,8 +66,10 @@ def approve_panel() -> InlineKeyboardMarkup:
             InlineKeyboardButton("✅ Approve", callback_data="approve_user"),
             InlineKeyboardButton("❌ Unapprove", callback_data="unapprove_user"),
         ],
-        [InlineKeyboardButton("📋 List", callback_data="view_approved")],
-        [InlineKeyboardButton("🔙 Back", callback_data="menu:main")],
+        [
+            InlineKeyboardButton("📋 List", callback_data="view_approved"),
+            InlineKeyboardButton("🔙 Back", callback_data="menu:main"),
+        ],
     ]
     return InlineKeyboardMarkup(rows)
 
@@ -90,8 +92,10 @@ def autodelete_panel() -> InlineKeyboardMarkup:
             InlineKeyboardButton("1h", callback_data="set_autodel:3600"),
             InlineKeyboardButton("24h", callback_data="set_autodel:86400"),
         ],
-        [InlineKeyboardButton("Off", callback_data="set_autodel:0")],
-        [InlineKeyboardButton("🔙 Back", callback_data="menu:main")],
+        [
+            InlineKeyboardButton("Off", callback_data="set_autodel:0"),
+            InlineKeyboardButton("🔙 Back", callback_data="menu:main"),
+        ],
     ]
     return InlineKeyboardMarkup(rows)
 


### PR DESCRIPTION
## Summary
- notify group when deleting a message because of bio links
- read bio via `get_chat` so deletions work again
- compact approval and auto-delete menus

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6865f182fe74832993cc21b14c8eefbc