### PR TITLE
Improve bot panel layouts

### DIFF
--- a/oxeign/minbot/start.py
+++ b/oxeign/minbot/start.py
@@ -9,7 +9,7 @@ from .panel import send_panel
 
 async def start_cmd(client: Client, message):
     private = message.chat.type == "private"
-    await send_panel(client, message, private=private)
+    await send_panel(client, message, private=private, start=True)
     if private:
         await log_to_channel(
             client,


### PR DESCRIPTION
## Summary
- add dedicated start panels for groups and private chats
- update control panel layout
- tweak submenus for bio and auto-delete options
- show the start panel on `/start`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6865f639c5208329b63ba621e8b058f2