### PR TITLE
Implement warnings for spammy bios

### DIFF
--- a/oxeign/swagger/warnings.py
+++ b/oxeign/swagger/warnings.py
@@ -1,0 +1,30 @@
+from typing import Dict
+
+from . import db
+
+warnings_col = db["bio_warnings"]
+
+
+async def add_warning(chat_id: int, user_id: int) -> int:
+    field = f"warnings.{user_id}"
+    await warnings_col.update_one({"chat_id": chat_id}, {"$inc": {field: 1}}, upsert=True)
+    data = await warnings_col.find_one({"chat_id": chat_id})
+    return int(data.get("warnings", {}).get(str(user_id), 0))
+
+
+async def clear_warnings(chat_id: int, user_id: int) -> None:
+    field = f"warnings.{user_id}"
+    await warnings_col.update_one({"chat_id": chat_id}, {"$unset": {field: ""}}, upsert=True)
+
+
+async def get_warnings(chat_id: int, user_id: int) -> int:
+    data = await warnings_col.find_one({"chat_id": chat_id})
+    return int(data.get("warnings", {}).get(str(user_id), 0)) if data else 0
+
+
+async def get_all_warnings(chat_id: int) -> Dict[int, int]:
+    data = await warnings_col.find_one({"chat_id": chat_id})
+    if not data:
+        return {}
+    return {int(uid): int(count) for uid, count in data.get("warnings", {}).items()}
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pyrogram==2.0.106
 tgcrypto
 motor
 python-dotenv
+python-telegram-bot==20.3


### PR DESCRIPTION
## Summary
- integrate Telegram bot library
- add persistent warnings storage via MongoDB
- check user bios and automatically warn or mute
- expose `/clearwarn` and `/warnlist` commands

## Testing
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_b_6865fce523ac832987700cdc7cfe06e6