### PR TITLE
Fix ChatMemberStatus import for PTB 20

### DIFF
--- a/oxeign/minbot/biofilter.py
+++ b/oxeign/minbot/biofilter.py
@@ -2,7 +2,8 @@ import logging
 import re
 from typing import Dict
 
-from telegram import Update, ChatPermissions, ChatMemberStatus
+from telegram import Update, ChatPermissions
+from telegram.constants import ChatMemberStatus
 from telegram.ext import (
     Application,
     CallbackContext,


### PR DESCRIPTION
## Summary
- fix import path for `ChatMemberStatus` in biofilter to support python-telegram-bot 20

## Testing
- `python -m compileall -q oxeign/minbot/biofilter.py`

------
https://chatgpt.com/codex/tasks/task_b_6865fea652008329b2a0f1dc6b811d16