### PR TITLE
Fix bio link filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ A lightweight Telegram bot built with **Pyrogram 2.x** for basic group moderatio
 
 ## Features
 
-- **Bio Link Filter** – blocks users with Telegram links in their bio unless approved
+- **Bio Link Filter** – blocks users with Telegram or other invite links in their bio and deletes the join message
+- **Spam Link Filter** – deletes messages that contain spam links and warns the sender
 - **Auto Delete Timer** – automatically deletes all messages after a configured delay
 - Admins manage everything via the `/panel` button menu
 

--- a/oxeign/minbot/biofilter.py
+++ b/oxeign/minbot/biofilter.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import Dict
 
 from pyrogram import Client, filters
@@ -14,8 +15,82 @@ from oxeign.swagger.warnings import (
     get_all_warnings,
 )
 
-BIO_KEYWORDS = ["t.me", "joinchat", "onlyfans", "wa.me", "http", "https"]
+# detect any obvious invite or external links in bios/messages
+LINK_RE = re.compile(r"(https?://|t\.me|telegram\.me|wa\.me|joinchat|onlyfans)", re.I)
+
+
+def has_spam_link(text: str) -> bool:
+    """Return True if the text contains a spam or invite link."""
+    return bool(LINK_RE.search(text))
+
+
 logger = logging.getLogger(__name__)
+
+
+async def _warn(
+    client: Client, chat_id: int, user_id: int, message: Message, reason: str
+) -> None:
+    warns = await add_warning(chat_id, user_id)
+    logger.info(
+        "%s warning %s/%s for user %s in chat %s",
+        reason,
+        warns,
+        3,
+        user_id,
+        chat_id,
+    )
+    if warns >= 3:
+        try:
+            await client.restrict_chat_member(
+                chat_id, user_id, ChatPermissions(can_send_messages=False)
+            )
+        except Exception as exc:
+            logger.warning("Failed to mute user %s: %s", user_id, exc)
+        await message.chat.send_message("🚫 You’ve been muted for spam.")
+    else:
+        await message.chat.send_message(
+            f"⚠️ Warning {warns}/3 – Stop posting spam links or you’ll be muted."
+        )
+
+
+async def _process_user_bio(
+    client: Client, chat_id: int, user_id: int, message: Message
+) -> bool:
+    if await is_admin(client, chat_id, user_id):
+        return False
+    if await is_approved(chat_id, user_id):
+        return False
+    try:
+        user_chat = await client.get_users(user_id)
+        bio = user_chat.bio or ""
+    except Exception:
+        bio = ""
+    if has_spam_link(bio or ""):
+        try:
+            await message.delete()
+        except Exception:
+            pass
+        await _warn(client, chat_id, user_id, message, "Bio")
+        return True
+    return False
+
+
+async def _process_message_links(
+    client: Client, chat_id: int, user_id: int, message: Message
+) -> bool:
+    if await is_admin(client, chat_id, user_id):
+        return False
+    if await is_approved(chat_id, user_id):
+        return False
+    text = message.text or message.caption or ""
+    if has_spam_link(text):
+        try:
+            await message.delete()
+        except Exception:
+            pass
+        await _warn(client, chat_id, user_id, message, "Message")
+        return True
+    return False
 
 
 async def check_bio(client: Client, message: Message) -> None:
@@ -27,39 +102,27 @@ async def check_bio(client: Client, message: Message) -> None:
     user_id = message.from_user.id
     if not await is_biomode(chat_id):
         return
-    if await is_admin(client, chat_id, user_id):
+    flagged = await _process_message_links(client, chat_id, user_id, message)
+    flagged |= await _process_user_bio(client, chat_id, user_id, message)
+
+
+async def check_new_members(client: Client, message: Message) -> None:
+    if message.chat.type not in ("group", "supergroup"):
         return
-    if await is_approved(chat_id, user_id):
+    if not message.new_chat_members:
         return
-    try:
-        user_chat = await client.get_users(user_id)
-        bio = user_chat.bio or ""
-    except Exception:
-        bio = ""
-    lower_bio = bio.lower()
-    if any(key in lower_bio for key in BIO_KEYWORDS):
-        warns = await add_warning(chat_id, user_id)
-        logger.info(
-            "Bio warning %s/%s for user %s in chat %s",
-            warns,
-            3,
-            user_id,
-            chat_id,
-        )
-        if warns >= 3:
-            try:
-                await client.restrict_chat_member(
-                    chat_id, user_id, ChatPermissions(can_send_messages=False)
-                )
-            except Exception as exc:
-                logger.warning("Failed to mute user %s: %s", user_id, exc)
-            await message.chat.send_message(
-                "🚫 You’ve been muted for having a spammy bio."
-            )
-        else:
-            await message.chat.send_message(
-                f"⚠️ Warning {warns}/3 – Please remove bio link or you’ll be muted."
-            )
+    chat_id = message.chat.id
+    if not await is_biomode(chat_id):
+        return
+    flagged = False
+    for member in message.new_chat_members:
+        if await _process_user_bio(client, chat_id, member.id, message):
+            flagged = True
+    if flagged:
+        try:
+            await message.delete()
+        except Exception:
+            pass
 
 
 async def clearwarn(client: Client, message: Message) -> None:
@@ -107,6 +170,9 @@ async def warnlist(client: Client, message: Message) -> None:
 
 def register(app: Client) -> None:
     app.add_handler(MessageHandler(check_bio, filters.group & ~filters.service))
+    app.add_handler(
+        MessageHandler(check_new_members, filters.group & filters.new_chat_members)
+    )
     app.add_handler(
         MessageHandler(clearwarn, filters.command("clearwarn") & filters.group)
     )

--- a/oxeign/minbot/grouptrack.py
+++ b/oxeign/minbot/grouptrack.py
@@ -7,6 +7,8 @@ from oxeign.utils.logger import log_to_channel
 
 
 async def track_updates(client: Client, update: ChatMemberUpdated):
+    if not update.new_chat_member or not update.new_chat_member.user:
+        return
     if not update.new_chat_member.user.is_self:
         return
     status = update.new_chat_member.status

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyrogram==2.0.106
 tgcrypto
+pymongo
 motor
 python-dotenv
-python-telegram-bot==20.3


### PR DESCRIPTION
## Summary
- improve spam link detection using regex
- delete join messages for users with spam links in their bio
- document updated behaviour in README
- add `pymongo` to requirements
- fix return values in spam filter helpers

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black --check oxeign/minbot/biofilter.py oxeign/minbot/grouptrack.py`


------
https://chatgpt.com/codex/tasks/task_b_6866087a931483299af3efb9ada798f1