### PR TITLE
Improve bio filter warnings

### DIFF
--- a/oxeign/minbot/biofilter.py
+++ b/oxeign/minbot/biofilter.py
@@ -1,3 +1,12 @@
+"""Bio filter that warns and mutes users with non-empty biographies.
+
+This module requires Pyrogram v2.x and Python 3.10+ and should only run in
+groups or supergroups where bio mode is enabled through :func:`is_biomode`.
+It relies on :func:`is_admin` and :func:`is_approved` to exempt privileged
+users. Warnings are stored in memory and after exceeding ``MAX_WARNINGS`` the
+user is muted using :py:meth:`Client.restrict_chat_member`.
+"""
+
 import logging
 from typing import Dict, Tuple
 
@@ -10,6 +19,9 @@ from oxeign.swagger.biomode import is_biomode
 from oxeign.swagger.approvals import is_approved
 
 logger = logging.getLogger(__name__)
+
+# maximum number of warnings before muting
+MAX_WARNINGS = 3
 
 # track warnings per (chat_id, user_id)
 user_warnings: Dict[Tuple[int, int], int] = {}
@@ -47,9 +59,20 @@ async def bio_filter(client: Client, message: Message) -> None:
     warn = user_warnings.get((chat_id, user_id), 0) + 1
     user_warnings[(chat_id, user_id)] = warn
 
-    if warn < 3:
-        await message.reply_text(f"⚠️ Warning {warn}/3: Bio not allowed here.")
+    if warn <= MAX_WARNINGS:
+        await message.reply_text(
+            f"⚠️ Warning {warn}/{MAX_WARNINGS}: Bio not allowed here."
+        )
     else:
+        try:
+            bot = await client.get_chat_member(chat_id, client.me.id)
+            if not (bot.privileges and bot.privileges.can_restrict_members):
+                logger.warning("Missing restrict permission in %s", chat_id)
+                return
+        except Exception as exc:  # pragma: no cover - network failures
+            logger.error("Failed to check bot permissions in %s: %s", chat_id, exc)
+            return
+
         try:
             await client.restrict_chat_member(chat_id, user_id, ChatPermissions())
         except Exception as exc:  # pragma: no cover - network failures


### PR DESCRIPTION
## Summary
- add module documentation and define MAX_WARNINGS
- warn users three times before muting
- check bot can restrict members before muting

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_686615318c6883298b229388939db5cd