### PR TITLE
Improve bio moderation persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A lightweight Telegram bot built with **Pyrogram 2.x** for basic group moderatio
 
 ## Features
 
-- **Bio Link Filter** – blocks users with Telegram or other invite links in their bio and deletes the join message
-- **Spam Link Filter** – deletes messages that contain spam links and warns the sender
+- **Bio Filter** – warns and eventually mutes users that have any biography set when bio mode is enabled
+- **Approved Users** – admins can approve or unapprove users to bypass the bio filter
 - **Auto Delete Timer** – automatically deletes all messages after a configured delay
 - Admins manage everything via the `/panel` button menu
 


### PR DESCRIPTION
## Summary
- store bio warnings in MongoDB using new warnings helpers
- document new approved users system and updated bio filter features in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68661885b8d08329b518adca752df56d