### PR TITLE
Resolve merge conflicts and integrate moderation features

### DIFF
--- a/handlers/approval.py
+++ b/handlers/approval.py
@@ -30,3 +30,23 @@ async def unapprove_user(client: Client, message: Message) -> None:
     user = message.reply_to_message.from_user
     await storage.unapprove_user(message.chat.id, user.id)
     await message.reply_text(f"❌ {user.mention} unapproved.")
+
+
+@Client.on_message(filters.command("approved") & filters.group)
+async def list_approved(client: Client, message: Message) -> None:
+    """List all approved users in the chat."""
+    member = await client.get_chat_member(message.chat.id, message.from_user.id)
+    if not await is_user_admin(member):
+        return
+    users = await storage.get_approved_users(message.chat.id)
+    if not users:
+        await message.reply_text("No approved users.")
+        return
+    mentions = []
+    for uid in users:
+        user = await client.get_users(uid)
+        mentions.append(user.mention)
+    await message.reply_text(
+        "*Approved users:*\n" + "\n".join(mentions),
+        parse_mode="Markdown",
+    )

--- a/handlers/autodelete.py
+++ b/handlers/autodelete.py
@@ -6,14 +6,16 @@ from pyrogram.types import Message
 
 from utils.storage import Storage
 from utils.perms import is_user_admin
+from handlers.logs import log
 
 storage = Storage()
 
 
 async def schedule_deletion(client: Client, message: Message, delay: int) -> None:
-    """Delete a message after delay seconds."""
+    """Delete a message after ``delay`` seconds."""
     await asyncio.sleep(delay)
     await client.delete_messages(message.chat.id, message.id, revoke=True)
+    await log(client, f"🧹 Deleted a message in `{message.chat.id}` after {delay}s")
 
 
 @Client.on_message(filters.command("setautodelete") & filters.group)
@@ -27,7 +29,9 @@ async def set_auto_delete(client: Client, message: Message) -> None:
         return
     value = message.command[1].lower()
     delay: int = 0
-    if value.endswith("h"):
+    if value == "off":
+        delay = 0
+    elif value.endswith("h") and value[:-1].isdigit():
         hours = int(value[:-1])
         delay = hours * 3600
     elif value.isdigit():
@@ -48,3 +52,4 @@ async def apply_autodelete(client: Client, message: Message) -> None:
     if await is_user_admin(member):
         return
     asyncio.create_task(schedule_deletion(client, message, delay))
+

--- a/handlers/panel.py
+++ b/handlers/panel.py
@@ -1,7 +1,16 @@
 """Inline control panel."""
 
 from pyrogram import Client, filters
-from pyrogram.types import InlineKeyboardButton, InlineKeyboardMarkup, Message
+from pyrogram.types import (
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    Message,
+    CallbackQuery,
+)
+
+from utils.storage import Storage
+
+storage = Storage()
 
 
 PANEL = InlineKeyboardMarkup(
@@ -12,7 +21,7 @@ PANEL = InlineKeyboardMarkup(
          InlineKeyboardButton("❌ Unapprove", callback_data="unapprove")],
         [InlineKeyboardButton("📋 View Approved", callback_data="list")],
         [InlineKeyboardButton("📣 Support Channel", url="https://t.me/botsyard")],
-        [InlineKeyboardButton("👨‍💻 Developer", url="https://t.me/oxeigm")],
+        [InlineKeyboardButton("👨‍💻 Developer", url="https://t.me/oxeign")],
         [InlineKeyboardButton("❎ Close Panel", callback_data="close")],
     ]
 )
@@ -27,3 +36,24 @@ async def open_panel(client: Client, message: Message) -> None:
         parse_mode="Markdown",
         disable_web_page_preview=True,
     )
+
+@Client.on_callback_query(filters.regex("^close$"))
+async def close_panel(_, query: CallbackQuery) -> None:
+    """Close the inline panel."""
+    await query.message.delete()
+
+
+@Client.on_callback_query(filters.regex("^list$"))
+async def show_approved(client: Client, query: CallbackQuery) -> None:
+    """Display approved users via callback."""
+    users = await storage.get_approved_users(query.message.chat.id)
+    if not users:
+        text = "No approved users."
+    else:
+        mentions = []
+        for uid in users:
+            user = await client.get_users(uid)
+            mentions.append(user.mention)
+        text = "*Approved users:*\n" + "\n".join(mentions)
+    await query.message.edit_text(text, parse_mode="Markdown")
+

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from pyrogram import Client, filters, idle
 
 from config import config
@@ -11,6 +12,7 @@ import handlers.logs
 
 async def main() -> None:
     """Start the Telegram bot."""
+    logging.basicConfig(level=getattr(logging, config.log_level.upper(), "INFO"))
     app = Client(
         "guard_bot",
         api_id=config.api_id,

--- a/utils/storage.py
+++ b/utils/storage.py
@@ -1,7 +1,8 @@
 """MongoDB storage helpers."""
 
-from typing import Optional
+from typing import List, Optional
 from motor.motor_asyncio import AsyncIOMotorClient
+from pymongo import ReturnDocument
 
 from config import config
 
@@ -22,7 +23,7 @@ class Storage:
             {"chat_id": chat_id, "user_id": user_id},
             {"$inc": {"count": 1}},
             upsert=True,
-            return_document=True,
+            return_document=ReturnDocument.AFTER,
         )
         return res["count"]
 
@@ -48,6 +49,10 @@ class Storage:
             await self.approvals.find_one({"chat_id": chat_id, "user_id": user_id})
         )
 
+    async def get_approved_users(self, chat_id: int) -> List[int]:
+        """Return a list of approved user IDs for a chat."""
+        cursor = self.approvals.find({"chat_id": chat_id})
+        return [doc["user_id"] async for doc in cursor]
     async def get_settings(self, chat_id: int) -> dict:
         """Retrieve group settings."""
         data = await self.settings.find_one({"chat_id": chat_id})


### PR DESCRIPTION
## Summary
- merge branch `0kauta-codex/build-telegram-moderation-bot-with-pyrogram-and-mongodb`
- resolve conflicts with `main`
- add approved-users list command
- extend auto-delete options and logging
- implement `/biomode` command and extra logging
- add callbacks for closing and listing approved users
- return approved users from storage and log level setup

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_b_6866259fc39c8329bab95c338e421990