### PR TITLE
Fix log channel crash

### DIFF
--- a/handlers/logs.py
+++ b/handlers/logs.py
@@ -12,11 +12,15 @@ async def log(client: Client, text: str) -> None:
     """Send a log message if a log channel is configured."""
     if not config.log_channel_id:
         return
-    await client.send_message(
-        config.log_channel_id,
-        text,
-        parse_mode=ParseMode.MARKDOWN,
-    )
+    try:
+        await client.send_message(
+            config.log_channel_id,
+            text,
+            parse_mode=ParseMode.MARKDOWN,
+        )
+    except Exception:
+        # Ignore logging errors such as invalid channel ID
+        pass
 
 
 async def start_log(client: Client, message: Message) -> None:


### PR DESCRIPTION
## Summary
- add exception handling when sending messages to the log channel

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68662c80ecb483298c08ad9bd5d66963