### PR TITLE
Improve config validation and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,19 @@
+# Telegram API credentials
 API_ID=
 API_HASH=
 BOT_TOKEN=
+
+# MongoDB connection URI
 MONGO_URI=
+
+# Owner user ID
 OWNER_ID=
+
+# Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
 LOG_LEVEL=INFO
+
+# Optional log channel ID
 LOG_CHANNEL_ID=
+
+# Optional start image URL
 START_IMAGE=

--- a/README.md
+++ b/README.md
@@ -7,3 +7,9 @@ A modern Telegram moderation bot built with Pyrogram and MongoDB. The bot scans 
 2. `pip install -r requirements.txt`
 3. Copy `.env.example` to `.env` and fill in values.
 4. Run `python main.py`
+
+### Required Environment Variables
+
+- `API_ID` and `API_HASH` from [my.telegram.org](https://my.telegram.org)
+- `BOT_TOKEN` from [@BotFather](https://t.me/BotFather)
+- `MONGO_URI` connection string to your MongoDB instance

--- a/config.py
+++ b/config.py
@@ -19,5 +19,21 @@ class Config:
     log_channel_id: int = int(getenv("LOG_CHANNEL_ID", 0))
     start_image: str = getenv("START_IMAGE", "")
 
+    def validate(self) -> None:
+        """Ensure required configuration values are present."""
+        missing = []
+        if not self.api_id:
+            missing.append("API_ID")
+        if not self.api_hash:
+            missing.append("API_HASH")
+        if not self.bot_token:
+            missing.append("BOT_TOKEN")
+        if not self.mongo_uri:
+            missing.append("MONGO_URI")
+        if missing:
+            names = ", ".join(missing)
+            raise RuntimeError(f"Missing required config values: {names}")
+
 
 config = Config()
+config.validate()


### PR DESCRIPTION
## Summary
- enforce configuration validation on import
- document required environment variables in README
- provide guidance in `.env.example`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py >/tmp/bot.log 2>&1 && tail -n 3 /tmp/bot.log`

------
https://chatgpt.com/codex/tasks/task_b_68662f4655048329a9359cf17b98a198