### PR TITLE
Improve env handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,19 @@
+# Telegram API credentials (no spaces around '=')
 API_ID=
 API_HASH=
 BOT_TOKEN=
+
+# MongoDB connection URI
 MONGO_URI=
+
+# Owner user ID
 OWNER_ID=
+
+# Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
 LOG_LEVEL=INFO
+
+# Optional log channel ID
 LOG_CHANNEL_ID=
+
+# Optional start image URL
 START_IMAGE=

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 .env
 session*
+*.session

--- a/README.md
+++ b/README.md
@@ -7,3 +7,12 @@ A modern Telegram moderation bot built with Pyrogram and MongoDB. The bot scans 
 2. `pip install -r requirements.txt`
 3. Copy `.env.example` to `.env` and fill in values.
 4. Run `python main.py`
+
+When filling out `.env`, ensure there are **no spaces** around the `=` sign,
+otherwise credentials may be read incorrectly.
+
+### Required Environment Variables
+
+- `API_ID` and `API_HASH` from [my.telegram.org](https://my.telegram.org)
+- `BOT_TOKEN` from [@BotFather](https://t.me/BotFather)
+- `MONGO_URI` connection string to your MongoDB instance

--- a/config.py
+++ b/config.py
@@ -11,13 +11,29 @@ class Config:
     """Dataclass for global configuration."""
 
     api_id: int = int(getenv("API_ID", 0))
-    api_hash: str = getenv("API_HASH", "")
-    bot_token: str = getenv("BOT_TOKEN", "")
-    mongo_uri: str = getenv("MONGO_URI", "")
+    api_hash: str = getenv("API_HASH", "").strip()
+    bot_token: str = getenv("BOT_TOKEN", "").strip()
+    mongo_uri: str = getenv("MONGO_URI", "").strip()
     owner_id: int = int(getenv("OWNER_ID", 0))
-    log_level: str = getenv("LOG_LEVEL", "INFO")
+    log_level: str = getenv("LOG_LEVEL", "INFO").strip()
     log_channel_id: int = int(getenv("LOG_CHANNEL_ID", 0))
-    start_image: str = getenv("START_IMAGE", "")
+    start_image: str = getenv("START_IMAGE", "").strip()
+
+    def validate(self) -> None:
+        """Ensure required configuration values are present."""
+        missing = []
+        if not self.api_id:
+            missing.append("API_ID")
+        if not self.api_hash:
+            missing.append("API_HASH")
+        if not self.bot_token:
+            missing.append("BOT_TOKEN")
+        if not self.mongo_uri:
+            missing.append("MONGO_URI")
+        if missing:
+            names = ", ".join(missing)
+            raise RuntimeError(f"Missing required config values: {names}")
 
 
 config = Config()
+config.validate()


### PR DESCRIPTION
## Summary
- strip whitespace from environment variables when loading config
- clarify env formatting in README and `.env.example`
- ignore `.session` files in gitignore

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `python main.py >/tmp/bot.log 2>&1 && tail -n 20 /tmp/bot.log` *(fails: ConnectionError)*


------
https://chatgpt.com/codex/tasks/task_b_68662f4655048329a9359cf17b98a198