### PR TITLE
Improve logging and add startup self-tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,9 @@ LOG_CHANNEL_ID=
 
 # Optional start image URL
 START_IMAGE=
+
+# Log file path
+LOG_FILE=bot.log
+
+# Run self tests on startup (true/false)
+RUN_SELF_TESTS=false

--- a/README.md
+++ b/README.md
@@ -20,3 +20,5 @@ A modern Telegram moderation bot built with Pyrogram and MongoDB. The bot scans 
 - `LOG_LEVEL` logging verbosity (default `INFO`)
 - `LOG_CHANNEL_ID` chat ID for log messages
 - `START_IMAGE` URL of the image to show on `/start`
+- `LOG_FILE` path to the log file (default `bot.log`)
+- `RUN_SELF_TESTS` run built-in command tests on startup (`true`/`false`)

--- a/config.py
+++ b/config.py
@@ -35,6 +35,8 @@ class Config:
     log_level: str = get_env("LOG_LEVEL", "INFO")
     log_channel_id: int = get_env("LOG_CHANNEL_ID", 0, cast=int)
     start_image: str = get_env("START_IMAGE", "")
+    log_file: str = get_env("LOG_FILE", "bot.log")
+    run_self_tests: bool = get_env("RUN_SELF_TESTS", False, cast=bool)
 
     def validate(self) -> None:
         """Ensure required configuration values are present."""


### PR DESCRIPTION
## Summary
- support extra configuration variables `LOG_FILE` and `RUN_SELF_TESTS`
- write README and `.env.example` docs for new options
- improve `/start` when `START_IMAGE` is unset
- log to file and optionally run command self-tests on startup

## Testing
- `python -m py_compile config.py main.py handlers/*.py utils/*.py`

------
https://chatgpt.com/codex/tasks/task_b_68663b085fc883298d66a183a790c706