### PR TITLE
Improve logging and startup tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,12 @@ LOG_CHANNEL_ID=
 
 # Optional start image URL
 START_IMAGE=
+
+# Log file path
+LOG_FILE=bot.log
+
+# Run self tests on startup (true/false)
+RUN_SELF_TESTS=false
+
+# Port for the health check server
+PORT=8080

--- a/README.md
+++ b/README.md
@@ -20,3 +20,6 @@ A modern Telegram moderation bot built with Pyrogram and MongoDB. The bot scans 
 - `LOG_LEVEL` logging verbosity (default `INFO`)
 - `LOG_CHANNEL_ID` chat ID for log messages
 - `START_IMAGE` URL of the image to show on `/start`
+- `LOG_FILE` path to the log file (default `bot.log`)
+- `RUN_SELF_TESTS` run built-in command tests on startup (`true`/`false`)
+- `PORT` port for the built-in health server (default `8080`)

--- a/config.py
+++ b/config.py
@@ -35,6 +35,8 @@ class Config:
     log_level: str = get_env("LOG_LEVEL", "INFO")
     log_channel_id: int = get_env("LOG_CHANNEL_ID", 0, cast=int)
     start_image: str = get_env("START_IMAGE", "")
+    log_file: str = get_env("LOG_FILE", "bot.log")
+    run_self_tests: bool = get_env("RUN_SELF_TESTS", False, cast=bool)
 
     def validate(self) -> None:
         """Ensure required configuration values are present."""

--- a/main.py
+++ b/main.py
@@ -1,33 +1,66 @@
 import asyncio
 import logging
+import os
+import threading
+import http.server
+from typing import Iterable
+
 from pyrogram import Client, filters, idle
 from pyrogram.enums import ParseMode
 
 from config import config
-import handlers.biofilter  # noqa: F401
-import handlers.autodelete  # noqa: F401
-import handlers.approval  # noqa: F401
-import handlers.panel  # noqa: F401
 import handlers.logs
+
+
+class HealthHandler(logging.Handler):
+    """Handler that writes logs to a file and stdout."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        print(self.format(record))
+
+
+def start_health_server() -> None:
+    """Expose a basic HTTP server for environments that require a port."""
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # type: ignore[override]
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"OK")
+
+    port = int(os.getenv("PORT", "8080"))
+    server = http.server.HTTPServer(("0.0.0.0", port), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    logging.info("Health server running on port %s", port)
 
 
 async def main() -> None:
     """Start the Telegram bot."""
-    logging.basicConfig(level=getattr(logging, config.log_level.upper(), "INFO"))
+    logging.basicConfig(
+        level=getattr(logging, config.log_level.upper(), "INFO"),
+        filename=config.log_file,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+    start_health_server()
     app = Client(
         "guard_bot",
         api_id=config.api_id,
         api_hash=config.api_hash,
         bot_token=config.bot_token,
+        plugins={"root": "handlers"},
     )
 
     @app.on_message(filters.private & filters.command("start"))
     async def start_handler(_, msg):
-        await msg.reply_photo(
-            config.start_image,
-            caption="Welcome!",
-            parse_mode=ParseMode.MARKDOWN,
-        )
+        if config.start_image:
+            await msg.reply_photo(
+                config.start_image,
+                caption="Welcome!",
+                parse_mode=ParseMode.MARKDOWN,
+            )
+        else:
+            await msg.reply_text("Welcome!", parse_mode=ParseMode.MARKDOWN)
         await handlers.logs.start_log(app, msg)
 
     @app.on_message(filters.new_chat_members)
@@ -40,7 +73,29 @@ async def main() -> None:
         if msg.left_chat_member and msg.left_chat_member.is_self:
             await handlers.logs.removed_from_group(app, msg.chat)
 
+    async def run_self_tests(commands: Iterable[str]) -> None:
+        """Send commands to the log channel and upload the log file."""
+        if not config.log_channel_id:
+            logging.info("No LOG_CHANNEL_ID set; skipping self tests")
+            return
+        for cmd in commands:
+            try:
+                await app.send_message(config.log_channel_id, cmd)
+                logging.info("Self test command sent: %s", cmd)
+                await asyncio.sleep(1)
+            except Exception as exc:
+                logging.exception("Failed to send %s: %s", cmd, exc)
+        try:
+            await app.send_document(
+                config.log_channel_id, config.log_file, caption="Self test logs"
+            )
+            logging.info("Self test logs uploaded")
+        except Exception as exc:
+            logging.exception("Failed to upload log file: %s", exc)
+
     await app.start()
+    if config.run_self_tests:
+        await run_self_tests(["/panel", "/approved", "/biomode", "/setautodelete off"])
     await idle()
     await app.stop()
 


### PR DESCRIPTION
## Summary
- support extra configuration variables `LOG_FILE` and `RUN_SELF_TESTS`
- add optional `PORT` to run a simple HTTP health server
- load handlers using Pyrogram plugin system
- log to file and optionally run command self-tests on startup

## Testing
- `python -m py_compile config.py main.py handlers/*.py utils/*.py`


------
https://chatgpt.com/codex/tasks/task_b_68663b085fc883298d66a183a790c706