### PR TITLE
Improve logging and add HTTP health server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,6 @@ LOG_FILE=bot.log
 
 # Run self tests on startup (true/false)
 RUN_SELF_TESTS=false
+
+# Port for optional health check server
+PORT=

--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ A modern Telegram moderation bot built with Pyrogram and MongoDB. The bot scans 
 - `START_IMAGE` URL of the image to show on `/start`
 - `LOG_FILE` path to the log file (default `bot.log`)
 - `RUN_SELF_TESTS` run built-in command tests on startup (`true`/`false`)
+- `PORT` port for optional HTTP health server

--- a/config.py
+++ b/config.py
@@ -37,6 +37,7 @@ class Config:
     start_image: str = get_env("START_IMAGE", "")
     log_file: str = get_env("LOG_FILE", "bot.log")
     run_self_tests: bool = get_env("RUN_SELF_TESTS", False, cast=bool)
+    port: int = get_env("PORT", 0, cast=int)
 
     def validate(self) -> None:
         """Ensure required configuration values are present."""


### PR DESCRIPTION
## Summary
- support new optional `PORT` env var for health check server
- log to both file and stdout
- load handlers using Pyrogram plugin system
- document new env var in README and `.env.example`

## Testing
- `python -m py_compile config.py main.py handlers/*.py utils/*.py`

------
https://chatgpt.com/codex/tasks/task_b_68663f6cb7e88329b083f1c785eb1fcf