### PR TITLE
Fix MongoDB startup error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pyrogram==2.0.106
 tgcrypto==1.2.5
 python-dotenv==1.0.1
-motor==3.4.0
+motor==3.7.1


### PR DESCRIPTION
## Summary
- bump `motor` to 3.7.1 to stay compatible with recent PyMongo

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py` *(fails: TypeError - missing environment variables)*

------
https://chatgpt.com/codex/tasks/task_b_68664916cb9883299ae6aa8f06ed6ae1