### PR TITLE
Fix DB init and graceful shutdown

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,4 +5,5 @@ load_dotenv()
 
 BOT_TOKEN = os.getenv("BOT_TOKEN")
 MONGO_URI = os.getenv("MONGO_URI")
+MONGO_DB_NAME = os.getenv("MONGO_DB_NAME")
 LOG_CHANNEL_ID = int(os.getenv("LOG_CHANNEL_ID"))

--- a/main.py
+++ b/main.py
@@ -27,15 +27,12 @@ def register_handlers():
 async def main():
     await init_db(MONGO_URI)
     register_handlers()
-    await app.start()
-    logger.info("Bot started")
-    await asyncio.Event().wait()
+    async with app:
+        logger.info("Bot started")
+        await asyncio.Event().wait()
+    await close_db()
+    logger.info("Bot stopped")
 
 
 if __name__ == "__main__":
-    try:
-        asyncio.run(main())
-    finally:
-        asyncio.run(close_db())
-        app.stop()
-        logger.info("Bot stopped")
+    asyncio.run(main())

--- a/utils/storage.py
+++ b/utils/storage.py
@@ -1,6 +1,8 @@
 """MongoDB storage utilities."""
 
 from motor.motor_asyncio import AsyncIOMotorClient
+from pymongo.errors import ConfigurationError
+from config import MONGO_DB_NAME
 
 client: AsyncIOMotorClient | None = None
 main = None
@@ -9,7 +11,12 @@ async def init_db(mongo_uri: str):
     """Initialise database connection."""
     global client, main
     client = AsyncIOMotorClient(mongo_uri)
-    main = client.get_default_database()
+    try:
+        main = client.get_default_database()
+    except ConfigurationError:
+        if not MONGO_DB_NAME:
+            raise
+        main = client[MONGO_DB_NAME]
 
 async def close_db():
     if client:


### PR DESCRIPTION
## Summary
- add `MONGO_DB_NAME` option
- handle missing DB name when connecting to Mongo
- use `async with` for clean startup/shutdown

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68664b8bab608329bc2c9eae27ec3f1f