### PR TITLE
Improve error message for missing MongoDB database name

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,6 @@ Only group admins can use these commands.
 
 
 If you encounter a `ConfigurationError` complaining about the default database,
-make sure the MongoDB URI contains a database name or set `MONGO_DB_NAME`
-explicitly.
+ensure that the `MONGO_URI` includes a database name or set the `MONGO_DB_NAME`
+environment variable. Without either of these, the application cannot determine
+which MongoDB database to use.

--- a/utils/storage.py
+++ b/utils/storage.py
@@ -13,9 +13,11 @@ async def init_db(mongo_uri: str):
     client = AsyncIOMotorClient(mongo_uri)
     try:
         main = client.get_default_database()
-    except ConfigurationError:
+    except ConfigurationError as e:
         if not MONGO_DB_NAME:
-            raise
+            raise ConfigurationError(
+                "No default database name defined in MONGO_URI and MONGO_DB_NAME is not set"
+            ) from e
         main = client[MONGO_DB_NAME]
 
 async def close_db():


### PR DESCRIPTION
## Summary
- clarify setup instructions for MongoDB database name
- raise a clearer ConfigurationError when no default database is provided

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_686689ae8ac883299b70597f51b751c6