### PR TITLE
Fallback to default MongoDB database when missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Guard is a simple moderation bot built with Pyrogram. It stores data in MongoDB 
 
 - `BOT_TOKEN` – Telegram bot token for your bot.
 - `MONGO_URI` – MongoDB connection string. If the URI does not include a database name, also set `MONGO_DB_NAME`.
-- `MONGO_DB_NAME` – *(optional)* name of the MongoDB database when it is not part of `MONGO_URI`.
+- `MONGO_DB_NAME` – *(optional)* name of the MongoDB database when it is not part of `MONGO_URI`. Defaults to `guard`.
 - `LOG_CHANNEL_ID` – Telegram channel ID where the bot sends log messages.
 
 ## Setup
@@ -18,7 +18,7 @@ pip install -r requirements.txt
 cat <<EOF > .env
 BOT_TOKEN=your_bot_token
 MONGO_URI=mongodb://localhost:27017/guard
-# Optional when the URI does not contain a DB name
+# Optional when the URI does not contain a DB name; defaults to "guard"
 MONGO_DB_NAME=guard
 LOG_CHANNEL_ID=-1001234567890
 EOF
@@ -45,5 +45,6 @@ Only group admins can use these commands.
 
 
 If you encounter a `ConfigurationError` complaining about the default database,
-make sure the MongoDB URI contains a database name or set `MONGO_DB_NAME`
-explicitly.
+ensure that the `MONGO_URI` includes a database name or set the `MONGO_DB_NAME`
+environment variable. When neither is provided, the bot falls back to a
+database named `guard`.

--- a/config.py
+++ b/config.py
@@ -5,5 +5,5 @@ load_dotenv()
 
 BOT_TOKEN = os.getenv("BOT_TOKEN")
 MONGO_URI = os.getenv("MONGO_URI")
-MONGO_DB_NAME = os.getenv("MONGO_DB_NAME")
+MONGO_DB_NAME = os.getenv("MONGO_DB_NAME", "guard")
 LOG_CHANNEL_ID = int(os.getenv("LOG_CHANNEL_ID"))

--- a/utils/storage.py
+++ b/utils/storage.py
@@ -14,8 +14,6 @@ async def init_db(mongo_uri: str):
     try:
         main = client.get_default_database()
     except ConfigurationError:
-        if not MONGO_DB_NAME:
-            raise
         main = client[MONGO_DB_NAME]
 
 async def close_db():


### PR DESCRIPTION
## Summary
- set a default database name (`guard`) in config
- simplify storage init logic to use the default
- document the fallback behaviour in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_686689ae8ac883299b70597f51b751c6