### PR TITLE
Fallback to default MongoDB database

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Guard is a simple moderation bot built with Pyrogram. It stores data in MongoDB 
 
 - `BOT_TOKEN` – Telegram bot token for your bot.
 - `MONGO_URI` – MongoDB connection string. If the URI does not include a database name, also set `MONGO_DB_NAME`.
-- `MONGO_DB_NAME` – *(optional)* name of the MongoDB database when it is not part of `MONGO_URI`.
+- `MONGO_DB_NAME` – *(optional)* name of the MongoDB database when it is not part of `MONGO_URI`. Defaults to `guard`.
 - `LOG_CHANNEL_ID` – Telegram channel ID where the bot sends log messages.
 
 ## Setup
@@ -18,7 +18,7 @@ pip install -r requirements.txt
 cat <<EOF > .env
 BOT_TOKEN=your_bot_token
 MONGO_URI=mongodb://localhost:27017/guard
-# Optional when the URI does not contain a DB name
+# Optional when the URI does not contain a DB name; defaults to "guard"
 MONGO_DB_NAME=guard
 LOG_CHANNEL_ID=-1001234567890
 EOF
@@ -46,5 +46,5 @@ Only group admins can use these commands.
 
 If you encounter a `ConfigurationError` complaining about the default database,
 ensure that the `MONGO_URI` includes a database name or set the `MONGO_DB_NAME`
-environment variable. Without either of these, the application cannot determine
-which MongoDB database to use.
+environment variable. When neither is provided, the bot falls back to a
+database named `guard`.

--- a/config.py
+++ b/config.py
@@ -5,5 +5,5 @@ load_dotenv()
 
 BOT_TOKEN = os.getenv("BOT_TOKEN")
 MONGO_URI = os.getenv("MONGO_URI")
-MONGO_DB_NAME = os.getenv("MONGO_DB_NAME")
+MONGO_DB_NAME = os.getenv("MONGO_DB_NAME", "guard")
 LOG_CHANNEL_ID = int(os.getenv("LOG_CHANNEL_ID"))

--- a/handlers/biofilter.py
+++ b/handlers/biofilter.py
@@ -1,6 +1,5 @@
 """Bio link detection and progressive moderation."""
 
-from datetime import datetime
 from pyrogram import Client, filters
 from pyrogram.types import Message, ChatPermissions
 
@@ -12,7 +11,6 @@ from utils.storage import (
     get_bio_filter,
 )
 from handlers.logs import log_event
-from config import LOG_CHANNEL_ID
 
 LINK_KEYWORDS = ["http", "https", "t.me", ".me", ".com", ".link"]
 

--- a/handlers/panel.py
+++ b/handlers/panel.py
@@ -3,7 +3,7 @@
 from pyrogram import Client, filters
 from pyrogram.types import Message, InlineKeyboardMarkup, InlineKeyboardButton, CallbackQuery
 
-from utils.storage import toggle_bio_filter, get_bio_filter, set_autodelete, get_autodelete
+from utils.storage import toggle_bio_filter, set_autodelete
 from utils.perms import is_admin
 
 PANEL_BUTTONS = [

--- a/utils/storage.py
+++ b/utils/storage.py
@@ -13,11 +13,7 @@ async def init_db(mongo_uri: str):
     client = AsyncIOMotorClient(mongo_uri)
     try:
         main = client.get_default_database()
-    except ConfigurationError as e:
-        if not MONGO_DB_NAME:
-            raise ConfigurationError(
-                "No default database name defined in MONGO_URI and MONGO_DB_NAME is not set"
-            ) from e
+    except ConfigurationError:
         main = client[MONGO_DB_NAME]
 
 async def close_db():


### PR DESCRIPTION
## Summary
- merge `8tr6c0-codex/fix-pymongo-configurationerror-for-default-database`
- default `MONGO_DB_NAME` to `guard`
- remove custom error handling in `init_db`
- document fallback behaviour in README
- clean up unused imports in handlers

## Testing
- `ruff check .`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68668c55e5048329abeab6a491eed10a