### PR TITLE
Fix log handler to support Pyrogram 2.0

### DIFF
--- a/handlers/logs.py
+++ b/handlers/logs.py
@@ -26,7 +26,7 @@ def register(app: Client):
     async def private_start(client: Client, message: Message):
         await log_event(client, "Bot started in private", message.from_user)
 
-    @app.on_my_chat_member()
+    @app.on_chat_member_updated()
     async def member_updates(client: Client, update: ChatMemberUpdated):
         if update.new_chat_member.status == "kicked":
             await log_event(client, "Bot was kicked", update.chat)


### PR DESCRIPTION
## Summary
- use `on_chat_member_updated` instead of `on_my_chat_member`

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68668f0c9c008329ae5203279d38813a