### PR TITLE
Add API credentials to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Guard is a simple moderation bot built with Pyrogram. It stores data in MongoDB 
 ## Required environment variables
 
 - `BOT_TOKEN` – Telegram bot token for your bot.
+- `API_ID` – integer API ID from https://my.telegram.org.
+- `API_HASH` – API hash from https://my.telegram.org.
 - `MONGO_URI` – MongoDB connection string. If the URI does not include a database name, also set `MONGO_DB_NAME`.
 - `MONGO_DB_NAME` – *(optional)* name of the MongoDB database when it is not part of `MONGO_URI`. Defaults to `guard`.
 - `LOG_CHANNEL_ID` – Telegram channel ID where the bot sends log messages.
@@ -17,6 +19,8 @@ Install dependencies and create a `.env` file with the required values:
 pip install -r requirements.txt
 cat <<EOF > .env
 BOT_TOKEN=your_bot_token
+API_ID=123456
+API_HASH=0123456789abcdef0123456789abcdef
 MONGO_URI=mongodb://localhost:27017/guard
 # Optional when the URI does not contain a DB name; defaults to "guard"
 MONGO_DB_NAME=guard

--- a/config.py
+++ b/config.py
@@ -4,6 +4,8 @@ from dotenv import load_dotenv
 load_dotenv()
 
 BOT_TOKEN = os.getenv("BOT_TOKEN")
+API_ID = int(os.getenv("API_ID"))
+API_HASH = os.getenv("API_HASH")
 MONGO_URI = os.getenv("MONGO_URI")
 MONGO_DB_NAME = os.getenv("MONGO_DB_NAME", "guard")
 LOG_CHANNEL_ID = int(os.getenv("LOG_CHANNEL_ID"))

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ import logging
 
 from pyrogram import Client
 
-from config import BOT_TOKEN, MONGO_URI
+from config import BOT_TOKEN, API_ID, API_HASH, MONGO_URI
 from handlers import biofilter, autodelete, approval, panel, logs
 from utils.storage import init_db, close_db
 
@@ -13,7 +13,12 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-app = Client("moderation-bot", bot_token=BOT_TOKEN)
+app = Client(
+    "moderation-bot",
+    bot_token=BOT_TOKEN,
+    api_id=API_ID,
+    api_hash=API_HASH,
+)
 
 
 def register_handlers():


### PR DESCRIPTION
## Summary
- configure `API_ID` and `API_HASH` in `config.py`
- pass API credentials to `Client`
- document new variables in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_686690de0c408329ab9c0eaf36df1192