### PR TITLE
Fix startup configuration for Pyrogram bot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,6 @@ MONGO_DB_NAME=guard
 LOG_CHANNEL_ID=
 # Optional settings
 BANNER_URL=
-UPDATE_CHANNEL_ID=
+UPDATE_CHANNEL_ID=0
 SUPPORT_CHAT_URL=https://t.me/botsyard
 DEVELOPER_URL=https://t.me/oxeign

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-worker: python main.py
+worker: sh start.sh

--- a/config.py
+++ b/config.py
@@ -1,14 +1,30 @@
+import logging
 import os
 from dotenv import load_dotenv
 
 load_dotenv()
 
-BOT_TOKEN = os.getenv("BOT_TOKEN")
-API_ID = int(os.getenv("API_ID"))
-API_HASH = os.getenv("API_HASH")
-MONGO_URI = os.getenv("MONGO_URI")
+logger = logging.getLogger(__name__)
+
+BOT_TOKEN = os.getenv("BOT_TOKEN", "")
+API_ID = int(os.getenv("API_ID", "0"))
+API_HASH = os.getenv("API_HASH", "")
+MONGO_URI = os.getenv("MONGO_URI", "")
 MONGO_DB_NAME = os.getenv("MONGO_DB_NAME", "guard")
-LOG_CHANNEL_ID = int(os.getenv("LOG_CHANNEL_ID"))
+LOG_CHANNEL_ID = int(os.getenv("LOG_CHANNEL_ID", "0"))
+
+_missing = [
+    name
+    for name, value in {
+        "BOT_TOKEN": BOT_TOKEN,
+        "API_ID": API_ID,
+        "API_HASH": API_HASH,
+    }.items()
+    if not value
+]
+if _missing:
+    logger.error("Missing required env vars: %s", ", ".join(_missing))
+    raise RuntimeError("Required environment variables are missing")
 
 # Optional configuration
 UPDATE_CHANNEL_ID = int(os.getenv("UPDATE_CHANNEL_ID", "0"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ pyrogram==2.0.106
 tgcrypto==1.2.5
 python-dotenv==1.0.1
 motor==3.7.1
+pymongo==4.6.3
+pyaes==1.6.1
+pysocks==1.7.1

--- a/start.sh
+++ b/start.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-python main.py
+set -e
+python -u main.py


### PR DESCRIPTION
## Summary
- enforce `.env` variables on startup
- log startup issues
- run the bot using `idle()`
- tighten up start script & Procfile
- add missing dependencies
- document env variables

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6866aa556ee88329a487c93ac33b61c5