### PR TITLE
Add Flask server to satisfy Render port check

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ motor==3.7.1
 pymongo==4.13.2
 pyaes==1.6.1
 pysocks==1.7.1
+Flask==3.0.2


### PR DESCRIPTION
## Summary
- keep Render alive by binding Flask to PORT in a background thread
- run the bot after Flask starts
- install Flask for the dummy web server

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6866af31a3ec8329a1791c1d16ff94a2