### PR TITLE
Fix Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM python:3.12-slim
 WORKDIR /app
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+# Install build tools required for packages like tgcrypto then remove them
+RUN apt-get update \ 
+    && apt-get install -y --no-install-recommends build-essential \ 
+    && pip install --no-cache-dir -r requirements.txt \ 
+    && apt-get purge -y --auto-remove build-essential \ 
+    && rm -rf /var/lib/apt/lists/*
 COPY . .
 CMD ["sh", "start.sh"]


### PR DESCRIPTION
## Summary
- install build-essential during Docker build so python packages compile

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- *(failed: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6866b03c6d9c8329bcca69203bd4833a