### PR TITLE
Fix fallback handler priority

### DIFF
--- a/main.py
+++ b/main.py
@@ -60,7 +60,7 @@ async def ping_cmd(_, message):
     await message.reply_text("pong")
 
 
-@bot.on_message(filters.private & ~filters.command(["start", "ping"]))
+@bot.on_message(filters.private & ~filters.command(["start", "ping"]), group=1)
 async def fallback_cmd(_, message):
     logger.info("Fallback message: %s", message.text)
     print("fallback handler executed")


### PR DESCRIPTION
## Summary
- ensure /help and other commands are processed before fallback

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6866b7649e0c83298ae9913f1a9651c9