### PR TITLE
Fix handler registration and logging

### DIFF
--- a/handlers/approval.py
+++ b/handlers/approval.py
@@ -1,15 +1,19 @@
 """User approval management."""
 
+import logging
 from pyrogram import Client, filters
 from pyrogram.types import Message
 
 from utils.storage import approve_user, unapprove_user, get_approved
 from utils.perms import is_admin
 
+logger = logging.getLogger(__name__)
+
 
 def register(app: Client):
     @app.on_message(filters.command("approve") & filters.group)
     async def approve_cmd(client: Client, message: Message):
+        logger.info("approve command in %s by %s", message.chat.id, message.from_user.id if message.from_user else None)
         if not await is_admin(client, message):
             return
         if not message.reply_to_message or not message.reply_to_message.from_user:
@@ -23,6 +27,7 @@ def register(app: Client):
 
     @app.on_message(filters.command("unapprove") & filters.group)
     async def unapprove_cmd(client: Client, message: Message):
+        logger.info("unapprove command in %s by %s", message.chat.id, message.from_user.id if message.from_user else None)
         if not await is_admin(client, message):
             return
         if not message.reply_to_message or not message.reply_to_message.from_user:
@@ -36,6 +41,7 @@ def register(app: Client):
 
     @app.on_message(filters.command("viewapproved") & filters.group)
     async def view_approved(client: Client, message: Message):
+        logger.info("viewapproved command in %s by %s", message.chat.id, message.from_user.id if message.from_user else None)
         if not await is_admin(client, message):
             return
         users = await get_approved(message.chat.id)

--- a/handlers/autodelete.py
+++ b/handlers/autodelete.py
@@ -1,15 +1,19 @@
 """Auto-delete messages after a delay."""
 
+import logging
 from pyrogram import Client, filters
 from pyrogram.types import Message
 
 from utils.storage import set_autodelete, get_autodelete
 from utils.perms import is_admin
 
+logger = logging.getLogger(__name__)
+
 
 def register(app: Client):
     @app.on_message(filters.command("setautodelete") & filters.group)
     async def set_autodel(client: Client, message: Message):
+        logger.info("setautodelete command in %s by %s", message.chat.id, message.from_user.id if message.from_user else None)
         if not await is_admin(client, message):
             return
         try:
@@ -27,6 +31,7 @@ def register(app: Client):
 
     @app.on_message(filters.group)
     async def autodelete_handler(client: Client, message: Message):
+        logger.debug("autodelete check in %s", message.chat.id)
         if message.service:
             return
         if await is_admin(client, message, message.from_user.id):

--- a/handlers/biofilter.py
+++ b/handlers/biofilter.py
@@ -1,5 +1,6 @@
 """Bio link detection and progressive moderation."""
 
+import logging
 from pyrogram import Client, filters
 from pyrogram.types import Message, ChatPermissions
 
@@ -12,6 +13,8 @@ from utils.storage import (
 )
 from handlers.logs import log_event
 
+logger = logging.getLogger(__name__)
+
 LINK_KEYWORDS = ["http", "https", "t.me", ".me", ".com", ".link"]
 
 
@@ -23,6 +26,7 @@ def contains_link(text: str) -> bool:
 def register(app: Client):
     @app.on_message(filters.group & filters.text)
     async def bio_filter(client: Client, message: Message):
+        logger.debug("bio_filter check in %s from %s", message.chat.id, message.from_user.id if message.from_user else None)
         user = message.from_user
         if not user or user.is_bot:
             return
@@ -63,6 +67,7 @@ def register(app: Client):
 
     @app.on_message(filters.new_chat_members)
     async def new_member_check(client: Client, message: Message):
+        logger.debug("new_member_check in %s", message.chat.id)
         if not await get_bio_filter(message.chat.id):
             return
         for user in message.new_chat_members:

--- a/handlers/commands.py
+++ b/handlers/commands.py
@@ -1,15 +1,24 @@
 """Basic bot commands."""
 
+import logging
 from pyrogram import Client, filters
-from pyrogram.types import Message, InlineKeyboardMarkup, InlineKeyboardButton, CallbackQuery
+from pyrogram.types import (
+    Message,
+    InlineKeyboardMarkup,
+    InlineKeyboardButton,
+    CallbackQuery,
+)
 
 from config import UPDATE_CHANNEL_ID, SUPPORT_CHAT_URL, DEVELOPER_URL
 from utils.perms import is_member_of
 
+logger = logging.getLogger(__name__)
+
 
 def register(app: Client):
-    @app.on_message(filters.command(["start", "help", "menu"]))
+    @app.on_message(filters.command("start"))
     async def start_cmd(client: Client, message: Message):
+        logger.info("/start from %s", message.chat.id)
         if message.chat.type != "private":
             await message.reply_text("ℹ️ Please DM me for details.")
             return
@@ -17,9 +26,19 @@ def register(app: Client):
         if UPDATE_CHANNEL_ID:
             if not await is_member_of(client, UPDATE_CHANNEL_ID, message.from_user.id):
                 button = InlineKeyboardMarkup(
-                    [[InlineKeyboardButton("Join Updates", url=f"https://t.me/{UPDATE_CHANNEL_ID}")]]
+                    [
+                        [
+                            InlineKeyboardButton(
+                                "Join Updates",
+                                url=f"https://t.me/{UPDATE_CHANNEL_ID}",
+                            )
+                        ]
+                    ]
                 )
-                await message.reply_text("Please join the update channel to use me.", reply_markup=button)
+                await message.reply_text(
+                    "Please join the update channel to use me.",
+                    reply_markup=button,
+                )
                 return
 
         user = message.from_user
@@ -35,7 +54,12 @@ def register(app: Client):
         me = await client.get_me()
         buttons = InlineKeyboardMarkup(
             [
-                [InlineKeyboardButton("➕ Add to Group", url=f"https://t.me/{me.username}?startgroup=true")],
+                [
+                    InlineKeyboardButton(
+                        "➕ Add to Group",
+                        url=f"https://t.me/{me.username}?startgroup=true",
+                    )
+                ],
                 [InlineKeyboardButton("ℹ️ Help", callback_data="help_tab")],
                 [
                     InlineKeyboardButton("👤 Developer", url=DEVELOPER_URL),
@@ -45,8 +69,26 @@ def register(app: Client):
         )
         await message.reply_text(text, reply_markup=buttons, parse_mode="Markdown")
 
+    @app.on_message(filters.command("help"))
+    async def help_cmd(client: Client, message: Message):
+        logger.info("/help from %s", message.chat.id)
+        if message.chat.type != "private":
+            await message.reply_text("ℹ️ Please DM me for help.")
+            return
+
+        help_text = (
+            "**Commands:**\n"
+            "/approve - approve user\n"
+            "/unapprove - unapprove user\n"
+            "/viewapproved - list approved\n"
+            "/setautodelete <sec> - auto delete messages\n"
+            "/panel - open control panel"
+        )
+        await message.reply_text(help_text, parse_mode="Markdown")
+
     @app.on_callback_query(filters.regex("^help_tab$"))
     async def help_cb(client: Client, query: CallbackQuery):
+        logger.info("help callback from %s", query.from_user.id)
         help_text = (
             "**Commands:**\n"
             "/approve - approve user\n"

--- a/handlers/logs.py
+++ b/handlers/logs.py
@@ -1,9 +1,12 @@
 """Logging utilities and handlers."""
 
+import logging
 from datetime import datetime
 from pyrogram import Client, filters
 from pyrogram.types import Chat, User, Message, ChatMemberUpdated
 from config import LOG_CHANNEL_ID
+
+logger = logging.getLogger(__name__)
 
 
 async def log_action_tracker(client: Client, chat: Chat, actor: User | None, action: str) -> None:
@@ -60,10 +63,12 @@ async def log_event(client: Client, action: str, source: Chat | User):
 def register(app: Client):
     @app.on_message(filters.command("start") & filters.private)
     async def private_start(client: Client, message: Message):
+        logger.debug("log private_start from %s", message.from_user.id)
         await log_event(client, "Bot started in private", message.from_user)
 
     @app.on_chat_member_updated()
     async def member_updates(client: Client, update: ChatMemberUpdated):
+        logger.debug("chat member update in %s", update.chat.id)
         if not update.new_chat_member.user.is_self:
             return
         if update.new_chat_member.status == "kicked":

--- a/handlers/panel.py
+++ b/handlers/panel.py
@@ -1,5 +1,6 @@
 """Settings panel with inline buttons."""
 
+import logging
 from pyrogram import Client, filters
 from pyrogram.types import (
     Message,
@@ -10,6 +11,8 @@ from pyrogram.types import (
 
 from config import BANNER_URL
 from utils.perms import is_admin
+
+logger = logging.getLogger(__name__)
 
 # Updated button grid (as per user request: removed Anti-Spam, Alphabets, Porn, Night)
 SETTINGS_PANEL = InlineKeyboardMarkup([
@@ -50,8 +53,9 @@ SETTINGS_PANEL = InlineKeyboardMarkup([
 
 
 def register(app: Client):
-    @app.on_message(filters.command(["start", "help", "menu"]))
+    @app.on_message(filters.command("panel"))
     async def open_panel(client: Client, message: Message):
+        logger.info("/panel from %s", message.chat.id)
         if message.chat.type == "private" or await is_admin(client, message):
             await message.reply_photo(
                 photo=BANNER_URL,
@@ -66,6 +70,7 @@ def register(app: Client):
 
     @app.on_callback_query()
     async def handle_clicks(client: Client, query: CallbackQuery):
+        logger.info("panel callback %s from %s", query.data, query.from_user.id)
         if query.data == "close":
             await query.message.delete()
             return

--- a/main.py
+++ b/main.py
@@ -46,24 +46,15 @@ def run_flask() -> None:
     flask_app.run(host="0.0.0.0", port=port, use_reloader=False)
 
 
-@bot.on_message(filters.command("start"))
-async def start_cmd(_, message):
-    logger.info("/start command received")
-    print("start handler executed")
-    await message.reply_text("Hello! I'm alive.")
-
-
 @bot.on_message(filters.command("ping"))
 async def ping_cmd(_, message):
     logger.info("/ping command received")
-    print("ping handler executed")
     await message.reply_text("pong")
 
 
-@bot.on_message(filters.private & ~filters.command(["start", "ping"]), group=1)
+@bot.on_message(filters.private & ~filters.command(["start", "help", "ping", "panel"]), group=1)
 async def fallback_cmd(_, message):
-    logger.info("Fallback message: %s", message.text)
-    print("fallback handler executed")
+    logger.info("Fallback handler triggered with text: %s", message.text)
     await message.reply_text("Received: " + (message.text or ""))
 
 


### PR DESCRIPTION
## Summary
- clean up overlapping commands
- add logging across handlers
- register `/panel` separately
- refine fallback handler

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `env BOT_TOKEN=123 API_ID=123 API_HASH=abc MONGO_URI=mongodb://localhost:27017/test LOG_CHANNEL_ID=0 python main.py` *(fails: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_6866b9f109c48329be1de7cdca960c81