### PR TITLE
Fix bot loops and admin checks

### DIFF
--- a/handlers/commands.py
+++ b/handlers/commands.py
@@ -86,6 +86,19 @@ def register(app: Client):
         )
         await message.reply_text(help_text, parse_mode="Markdown")
 
+    @app.on_message(filters.command("auth"))
+    async def auth_cmd(client: Client, message: Message):
+        logger.info("/auth from %s", message.chat.id)
+        if message.chat.type == "private":
+            await message.reply_text("This command can only be used in groups.")
+            return
+        try:
+            member = await client.get_chat_member(message.chat.id, message.from_user.id)
+            await message.reply_text(f"Your status: `{member.status}`", parse_mode="Markdown")
+        except Exception as exc:
+            logger.warning("auth check failed: %s", exc)
+            await message.reply_text("Couldn't check your status.")
+
     @app.on_callback_query(filters.regex("^help_tab$"))
     async def help_cb(client: Client, query: CallbackQuery):
         logger.info("help callback from %s", query.from_user.id)

--- a/main.py
+++ b/main.py
@@ -52,8 +52,14 @@ async def ping_cmd(_, message):
     await message.reply_text("pong")
 
 
-@bot.on_message(filters.private & ~filters.command(["start", "help", "ping", "panel"]), group=1)
+@bot.on_message(
+    filters.private
+    & ~filters.command(["start", "help", "ping", "panel"])
+    & ~filters.me,
+    group=1,
+)
 async def fallback_cmd(_, message):
+    """Reply in private chats when no command matches."""
     logger.info("Fallback handler triggered with text: %s", message.text)
     await message.reply_text("Received: " + (message.text or ""))
 

--- a/utils/perms.py
+++ b/utils/perms.py
@@ -1,12 +1,24 @@
 """Permission helpers."""
 
+import logging
 from pyrogram import Client
 from pyrogram.types import Message
 from pyrogram.enums import ChatMemberStatus
 
+logger = logging.getLogger(__name__)
+
 async def is_admin(client: Client, message: Message, user_id: int | None = None) -> bool:
+    """Return ``True`` if the user is an admin of the chat."""
+    if message.chat.type == "private":
+        return True
+
     user_id = user_id or message.from_user.id
-    member = await client.get_chat_member(message.chat.id, user_id)
+    try:
+        member = await client.get_chat_member(message.chat.id, user_id)
+    except Exception as exc:
+        logger.warning("get_chat_member failed: %s", exc)
+        return False
+
     return member.status in {ChatMemberStatus.ADMINISTRATOR, ChatMemberStatus.OWNER}
 
 
@@ -14,6 +26,7 @@ async def is_member_of(client: Client, chat_id: int, user_id: int) -> bool:
     """Return True if the user is a member of the given chat."""
     try:
         member = await client.get_chat_member(chat_id, user_id)
-    except Exception:
+    except Exception as exc:
+        logger.debug("get_chat_member(%s, %s) failed: %s", chat_id, user_id, exc)
         return False
     return member.status not in {ChatMemberStatus.KICKED, ChatMemberStatus.LEFT}


### PR DESCRIPTION
## Summary
- avoid recursive fallback responses
- make admin checks safe in private chats
- add `/auth` command

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_b_6866bc56b9ec83299c56907608dc145d