### PR TITLE
Fix handlers and bot initialization

### DIFF
--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -1,34 +1,22 @@
 """Expose all handler modules and provide a helper to register them."""
 
 from importlib import import_module
+from pathlib import Path
 from pyrogram import Client
 
-__all__ = [
-    "biofilter",
-    "autodelete",
-    "approval",
-    "panel",
-    "logs",
-    "commands",
+MODULES = [
+    p.stem
+    for p in Path(__file__).parent.glob("*.py")
+    if p.stem not in {"__init__"}
 ]
 
-MODULES = __all__
-
-# Pre-import modules so they are available when ``from handlers import ...`` is used
-from . import (  # noqa: E402
-    biofilter as _biofilter,  # noqa: F401
-    autodelete as _autodelete,  # noqa: F401
-    approval as _approval,  # noqa: F401
-    panel as _panel,  # noqa: F401
-    logs as _logs,  # noqa: F401
-    commands as _commands,  # noqa: F401
-)
+__all__ = MODULES
 
 
-def register_all(app: Client) -> None:
+def init_all(app: Client) -> None:
     """Register all handlers on the provided ``Client`` instance."""
     for name in MODULES:
         module = import_module(f".{name}", __name__)
-        register = getattr(module, "register", None)
-        if callable(register):
-            register(app)
+        init = getattr(module, "init", None)
+        if callable(init):
+            init(app)

--- a/handlers/approval.py
+++ b/handlers/approval.py
@@ -10,7 +10,7 @@ from utils.perms import is_admin
 logger = logging.getLogger(__name__)
 
 
-def register(app: Client):
+def init(app: Client) -> None:
     @app.on_message(filters.command("approve") & filters.group)
     async def approve_cmd(client: Client, message: Message):
         logger.info("approve command in %s by %s", message.chat.id, message.from_user.id if message.from_user else None)
@@ -22,7 +22,7 @@ def register(app: Client):
         user_id = message.reply_to_message.from_user.id
         await approve_user(message.chat.id, user_id)
         await message.reply_text(
-            f"✅ Approved `{user_id}`", parse_mode="Markdown"
+            f"✅ Approved `{user_id}`", parse_mode="markdown"
         )
 
     @app.on_message(filters.command("unapprove") & filters.group)
@@ -36,7 +36,7 @@ def register(app: Client):
         user_id = message.reply_to_message.from_user.id
         await unapprove_user(message.chat.id, user_id)
         await message.reply_text(
-            f"❌ Unapproved `{user_id}`", parse_mode="Markdown"
+            f"❌ Unapproved `{user_id}`", parse_mode="markdown"
         )
 
     @app.on_message(filters.command("viewapproved") & filters.group)
@@ -49,4 +49,4 @@ def register(app: Client):
             await message.reply_text("📭 No approved users.")
             return
         text = "**📋 Approved Users:**\n" + "\n".join(f"`{u}`" for u in users)
-        await message.reply_text(text, parse_mode="Markdown")
+        await message.reply_text(text, parse_mode="markdown")

--- a/handlers/autodelete.py
+++ b/handlers/autodelete.py
@@ -10,7 +10,7 @@ from utils.perms import is_admin
 logger = logging.getLogger(__name__)
 
 
-def register(app: Client):
+def init(app: Client) -> None:
     @app.on_message(filters.command("setautodelete") & filters.group)
     async def set_autodel(client: Client, message: Message):
         logger.info("setautodelete command in %s by %s", message.chat.id, message.from_user.id if message.from_user else None)
@@ -24,7 +24,7 @@ def register(app: Client):
         await set_autodelete(message.chat.id, seconds)
         if seconds > 0:
             await message.reply_text(
-                f"🕒 Auto-delete set to {seconds} seconds.", parse_mode="Markdown"
+                f"🕒 Auto-delete set to {seconds} seconds.", parse_mode="markdown"
             )
         else:
             await message.reply_text("❌ Auto-delete disabled.")

--- a/handlers/biofilter.py
+++ b/handlers/biofilter.py
@@ -23,7 +23,7 @@ def contains_link(text: str) -> bool:
     return any(k in lower for k in LINK_KEYWORDS)
 
 
-def register(app: Client):
+def init(app: Client) -> None:
     @app.on_message(filters.group & filters.text)
     async def bio_filter(client: Client, message: Message):
         logger.debug("bio_filter check in %s from %s", message.chat.id, message.from_user.id if message.from_user else None)

--- a/handlers/commands.py
+++ b/handlers/commands.py
@@ -15,10 +15,10 @@ from utils.perms import is_member_of
 logger = logging.getLogger(__name__)
 
 
-def register(app: Client):
-    @app.on_message(filters.command("start"))
+def init(app: Client) -> None:
+    @app.on_message(filters.command("menu"))
     async def start_cmd(client: Client, message: Message):
-        logger.info("/start from %s", message.chat.id)
+        logger.info("/menu from %s", message.chat.id)
         if message.chat.type != "private":
             await message.reply_text("ℹ️ Please DM me for details.")
             return
@@ -67,7 +67,7 @@ def register(app: Client):
                 ],
             ]
         )
-        await message.reply_text(text, reply_markup=buttons, parse_mode="Markdown")
+        await message.reply_text(text, reply_markup=buttons, parse_mode="markdown")
 
     @app.on_message(filters.command("help"))
     async def help_cmd(client: Client, message: Message):
@@ -82,9 +82,9 @@ def register(app: Client):
             "/unapprove - unapprove user\n"
             "/viewapproved - list approved\n"
             "/setautodelete <sec> - auto delete messages\n"
-            "/panel - open control panel"
+            "/start - open control panel"
         )
-        await message.reply_text(help_text, parse_mode="Markdown")
+        await message.reply_text(help_text, parse_mode="markdown")
 
     @app.on_message(filters.command("auth"))
     async def auth_cmd(client: Client, message: Message):
@@ -94,7 +94,7 @@ def register(app: Client):
             return
         try:
             member = await client.get_chat_member(message.chat.id, message.from_user.id)
-            await message.reply_text(f"Your status: `{member.status}`", parse_mode="Markdown")
+            await message.reply_text(f"Your status: `{member.status}`", parse_mode="markdown")
         except Exception as exc:
             logger.warning("auth check failed: %s", exc)
             await message.reply_text("Couldn't check your status.")
@@ -108,7 +108,7 @@ def register(app: Client):
             "/unapprove - unapprove user\n"
             "/viewapproved - list approved\n"
             "/setautodelete <sec> - auto delete messages\n"
-            "/panel - open control panel"
+            "/start - open control panel"
         )
-        await query.message.edit_text(help_text, parse_mode="Markdown")
+        await query.message.edit_text(help_text, parse_mode="markdown")
 

--- a/handlers/logs.py
+++ b/handlers/logs.py
@@ -42,7 +42,7 @@ async def log_action_tracker(client: Client, chat: Chat, actor: User | None, act
         ])
 
     lines.append("━━━━━━━━━━━━━━━━━━━━━━")
-    await client.send_message(LOG_CHANNEL_ID, "\n".join(lines), parse_mode="Markdown")
+    await client.send_message(LOG_CHANNEL_ID, "\n".join(lines), parse_mode="markdown")
 
 async def log_event(client: Client, action: str, source: Chat | User):
     if isinstance(source, Chat):
@@ -57,10 +57,10 @@ async def log_event(client: Client, action: str, source: Chat | User):
         f"{ident}\n"
         f"🕒 `{datetime.utcnow().isoformat()}`"
     )
-    await client.send_message(LOG_CHANNEL_ID, text, parse_mode="Markdown")
+    await client.send_message(LOG_CHANNEL_ID, text, parse_mode="markdown")
 
 
-def register(app: Client):
+def init(app: Client) -> None:
     @app.on_message(filters.command("start") & filters.private)
     async def private_start(client: Client, message: Message):
         logger.debug("log private_start from %s", message.from_user.id)

--- a/handlers/panel.py
+++ b/handlers/panel.py
@@ -52,10 +52,10 @@ SETTINGS_PANEL = InlineKeyboardMarkup([
 ])
 
 
-def register(app: Client):
-    @app.on_message(filters.command("panel"))
+def init(app: Client) -> None:
+    @app.on_message(filters.command("start"))
     async def open_panel(client: Client, message: Message):
-        logger.info("/panel from %s", message.chat.id)
+        logger.info("/start from %s", message.chat.id)
         if message.chat.type == "private" or await is_admin(client, message):
             await message.reply_photo(
                 photo=BANNER_URL,
@@ -65,7 +65,7 @@ def register(app: Client):
                     "Group: `BOTS ✺ YARD DISCUSSION`"
                 ),
                 reply_markup=SETTINGS_PANEL,
-                parse_mode="Markdown",
+                parse_mode="markdown",
             )
 
     @app.on_callback_query()
@@ -78,5 +78,5 @@ def register(app: Client):
         await query.answer()
         await query.message.edit_text(
             f"🛠 *You selected:* `{query.data}`\nThat setting's options will be shown soon.",
-            parse_mode="Markdown",
+            parse_mode="markdown",
         )


### PR DESCRIPTION
## Summary
- standardize handler registration via `init(app)`
- lower-case `parse_mode` for Pyrogram v2
- rename `/panel` command to `/start` and expose `/menu`
- dynamically load handler modules
- simplify bot startup to use `bot.run`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6866c0a14b7c83298b4babe28976fc9e