### PR TITLE
Fix webhook initialization

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from config import API_HASH, API_ID, BOT_TOKEN, MONGO_URI
 from handlers import init_all
 from utils.storage import close_db, init_db
 from utils.errors import catch_errors
+from utils.webhook import set_webhook
 
 WEBHOOK_URL = os.getenv("WEBHOOK_URL", "https://guard-4nfv.onrender.com")
 
@@ -80,7 +81,7 @@ async def main() -> None:
     logger.info("Initializing database connection")
     await init_db(MONGO_URI)
     init_all(bot)
-    await bot.set_webhook(WEBHOOK_URL)
+    await set_webhook(BOT_TOKEN, WEBHOOK_URL)
     logger.info("Webhook set to %s", WEBHOOK_URL)
     logger.info("Bot started and waiting for events")
     await idle()

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,3 +1,3 @@
-from . import perms, storage, errors
+from . import perms, storage, errors, webhook
 
-__all__ = ["perms", "storage", "errors"]
+__all__ = ["perms", "storage", "errors", "webhook"]

--- a/utils/webhook.py
+++ b/utils/webhook.py
@@ -1,0 +1,18 @@
+import asyncio
+import logging
+from urllib import request, parse, error
+
+logger = logging.getLogger(__name__)
+
+async def set_webhook(bot_token: str, url: str) -> None:
+    """Set the Telegram bot webhook via the Bot API."""
+    api_url = f"https://api.telegram.org/bot{bot_token}/setWebhook"
+    data = parse.urlencode({"url": url}).encode()
+    req = request.Request(api_url, data=data)
+    loop = asyncio.get_running_loop()
+    try:
+        resp = await loop.run_in_executor(None, request.urlopen, req)
+        resp.read()  # Consume response
+        logger.info("Webhook configured via Bot API")
+    except error.URLError as exc:
+        logger.error("Failed to set webhook: %s", exc)


### PR DESCRIPTION
## Summary
- add a helper to set the webhook using Telegram Bot API
- call the helper from the startup routine

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_6866c8e4b4308329870a93f34cf9d781