### PR TITLE
Switch bot to polling and add Render config

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ Guard is a simple moderation bot built with Pyrogram. It stores data in MongoDB 
 - `MONGO_DB_NAME` – *(optional)* name of the MongoDB database when it is not part of `MONGO_URI`. Defaults to `guard`.
 - `LOG_CHANNEL_ID` – Telegram channel ID where the bot sends log messages.
 - `BANNER_URL` – *(optional)* image URL displayed on the settings panel.
-- `WEBHOOK_URL` – *(optional)* public URL where Telegram will send updates when
-  deployed using webhooks. Defaults to `https://guard-4nfv.onrender.com`.
 
 ## Setup
 
@@ -45,6 +43,17 @@ python main.py
 For hosting platforms such as Heroku or Railway, this repository includes a
 `Procfile`, `runtime.txt`, and `start.sh` so the bot can be launched directly
 after deployment.
+
+### Render.com
+
+This repository also provides a `render.yaml` describing two services:
+
+- **`guard-web`** – a small Flask app exposing `/health` on port `10000`.
+- **`guard-bot`** – the background worker running the Pyrogram bot in polling
+  mode.
+
+Deploy the repo on Render using this file so the worker and web service share
+the same environment variables.
 
 ## Docker
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,11 @@
+services:
+  - type: web
+    name: guard-web
+    env: python
+    buildCommand: pip install -r requirements.txt
+    startCommand: python web.py
+  - type: worker
+    name: guard-bot
+    env: python
+    buildCommand: pip install -r requirements.txt
+    startCommand: python main.py

--- a/web.py
+++ b/web.py
@@ -1,0 +1,20 @@
+import logging
+import os
+from flask import Flask
+
+logging.basicConfig(
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    level=logging.INFO,
+)
+logger = logging.getLogger(__name__)
+
+app = Flask(__name__)
+
+@app.route("/health")
+def health() -> str:
+    return "OK"
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", 10000))
+    logger.info("Starting Flask health server on port %s", port)
+    app.run(host="0.0.0.0", port=port)


### PR DESCRIPTION
## Summary
- remove unused webhook and Flask server from `main.py`
- add dedicated `web.py` for a health endpoint
- document Render setup in README
- provide `render.yaml` with web and worker services

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6866cf06d0988329bc212b979c7a4753