### PR TITLE
Fix Pyrogram startup and add handler logging

### DIFF
--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -1,8 +1,11 @@
 """Expose all handler modules and provide a helper to register them."""
 
+import logging
 from importlib import import_module
 from pathlib import Path
 from pyrogram import Client
+
+logger = logging.getLogger(__name__)
 
 MODULES = [
     p.stem
@@ -19,4 +22,5 @@ def init_all(app: Client) -> None:
         module = import_module(f".{name}", __name__)
         init = getattr(module, "init", None)
         if callable(init):
+            logger.info("Registering handlers from %s", name)
             init(app)

--- a/main.py
+++ b/main.py
@@ -52,8 +52,9 @@ async def main() -> None:
     logger.info("Initializing database connection")
     await init_db(MONGO_URI)
     init_all(bot)
-    logger.info("Bot started and waiting for events")
-    await idle()
+    async with bot:
+        logger.info("Bot started and waiting for events")
+        await idle()
     await close_db()
     logger.info("Bot stopped")
 


### PR DESCRIPTION
## Summary
- start the bot properly using `async with bot` so handlers can run
- log which handler modules are registered for easier debugging

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6866d19532c88329a85d2df97abbef9d