### PR TITLE
Fix invalid parse_mode usages

### DIFF
--- a/handlers/approval.py
+++ b/handlers/approval.py
@@ -24,7 +24,7 @@ def init(app: Client) -> None:
         user_id = message.reply_to_message.from_user.id
         await approve_user(message.chat.id, user_id)
         await message.reply_text(
-            f"✅ Approved `{user_id}`", parse_mode="markdown"
+            f"✅ Approved <code>{user_id}</code>", parse_mode="html"
         )
 
     @app.on_message(filters.command("unapprove") & filters.group)
@@ -39,7 +39,7 @@ def init(app: Client) -> None:
         user_id = message.reply_to_message.from_user.id
         await unapprove_user(message.chat.id, user_id)
         await message.reply_text(
-            f"❌ Unapproved `{user_id}`", parse_mode="markdown"
+            f"❌ Unapproved <code>{user_id}</code>", parse_mode="html"
         )
 
     @app.on_message(filters.command("viewapproved") & filters.group)
@@ -52,5 +52,5 @@ def init(app: Client) -> None:
         if not users:
             await message.reply_text("📭 No approved users.")
             return
-        text = "**📋 Approved Users:**\n" + "\n".join(f"`{u}`" for u in users)
-        await message.reply_text(text, parse_mode="markdown")
+        text = "<b>📋 Approved Users:</b>\n" + "\n".join(f"<code>{u}</code>" for u in users)
+        await message.reply_text(text, parse_mode="html")

--- a/handlers/autodelete.py
+++ b/handlers/autodelete.py
@@ -26,7 +26,7 @@ def init(app: Client) -> None:
         await set_autodelete(message.chat.id, seconds)
         if seconds > 0:
             await message.reply_text(
-                f"🕒 Auto-delete set to {seconds} seconds.", parse_mode="markdown"
+                f"🕒 Auto-delete set to {seconds} seconds.", parse_mode="html"
             )
         else:
             await message.reply_text("❌ Auto-delete disabled.")

--- a/handlers/commands.py
+++ b/handlers/commands.py
@@ -21,14 +21,14 @@ def init(app: Client) -> None:
             return
 
         help_text = (
-            "**Commands:**\n"
+            "<b>Commands:</b>\n"
             "/approve - approve user\n"
             "/unapprove - unapprove user\n"
             "/viewapproved - list approved\n"
             "/setautodelete <sec> - auto delete messages\n"
             "/start - open control panel"
         )
-        await message.reply_text(help_text, parse_mode="markdown")
+        await message.reply_text(help_text, parse_mode="html")
 
     @app.on_message(filters.command("auth"))
     @catch_errors
@@ -39,7 +39,7 @@ def init(app: Client) -> None:
             return
         try:
             member = await client.get_chat_member(message.chat.id, message.from_user.id)
-            await message.reply_text(f"Your status: `{member.status}`", parse_mode="markdown")
+            await message.reply_text(f"Your status: <code>{member.status}</code>", parse_mode="html")
         except Exception as exc:
             logger.warning("auth check failed: %s", exc)
             await message.reply_text("Couldn't check your status.")
@@ -49,12 +49,12 @@ def init(app: Client) -> None:
     async def help_cb(client: Client, query: CallbackQuery):
         logger.info("help callback from %s", query.from_user.id)
         help_text = (
-            "**Commands:**\n"
+            "<b>Commands:</b>\n"
             "/approve - approve user\n"
             "/unapprove - unapprove user\n"
             "/viewapproved - list approved\n"
             "/setautodelete <sec> - auto delete messages\n"
             "/start - open control panel"
         )
-        await query.message.edit_text(help_text, parse_mode="markdown")
+        await query.message.edit_text(help_text, parse_mode="html")
 

--- a/handlers/logs.py
+++ b/handlers/logs.py
@@ -15,50 +15,50 @@ async def log_action_tracker(client: Client, chat: Chat, actor: User | None, act
     time_str = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
     if actor:
-        user_line = f"👤 [{actor.first_name}](tg://user?id={actor.id})"
-        id_line = f"🆔 `{actor.id}`"
+        user_line = f"👤 <a href=\"tg://user?id={actor.id}\">{actor.first_name}</a>"
+        id_line = f"🆔 <code>{actor.id}</code>"
     else:
         user_line = "👤 Unknown"
-        id_line = "🆔 `?`"
+        id_line = "🆔 <code>?</code>"
 
     lines = [
         "━━━━━━━━━━━━━━━━━━━━━━",
-        "📍 **BOT ACTION TRACKER**",
+        "📍 <b>BOT ACTION TRACKER</b>",
         user_line,
         id_line,
-        f"🕒 `{time_str}`",
+        f"🕒 <code>{time_str}</code>",
         "",
     ]
 
     if action == "removed":
         lines.extend([
-            "🗑️ *Removed from Group*",
-            f"Chat ID: `{chat.id}`",
+            "🗑️ <i>Removed from Group</i>",
+            f"Chat ID: <code>{chat.id}</code>",
             f"Chat Name: {chat.title or 'Private'}",
         ])
     elif action == "readded":
         lines.extend([
-            "➕ *Re-added to Group*",
+            "➕ <i>Re-added to Group</i>",
             f"By: {user_line if actor else 'Unknown'}",
         ])
 
     lines.append("━━━━━━━━━━━━━━━━━━━━━━")
-    await client.send_message(LOG_CHANNEL_ID, "\n".join(lines), parse_mode="markdown")
+    await client.send_message(LOG_CHANNEL_ID, "\n".join(lines), parse_mode="html")
 
 async def log_event(client: Client, action: str, source: Chat | User):
     if isinstance(source, Chat):
         name = source.title or "Private"
-        ident = f"🏷 {name}\n🆔 `{source.id}`"
+        ident = f"🏷 {name}\n🆔 <code>{source.id}</code>"
     else:
-        ident = f"[{source.first_name}](tg://user?id={source.id})\n🆔 `{source.id}`"
+        ident = f"<a href=\"tg://user?id={source.id}\">{source.first_name}</a>\n🆔 <code>{source.id}</code>"
 
     text = (
-        f"**📘 Bot Log**\n"
+        f"<b>📘 Bot Log</b>\n"
         f"🔹 Action: {action}\n"
         f"{ident}\n"
-        f"🕒 `{datetime.utcnow().isoformat()}`"
+        f"🕒 <code>{datetime.utcnow().isoformat()}</code>"
     )
-    await client.send_message(LOG_CHANNEL_ID, text, parse_mode="markdown")
+    await client.send_message(LOG_CHANNEL_ID, text, parse_mode="html")
 
 
 def init(app: Client) -> None:

--- a/handlers/menu.py
+++ b/handlers/menu.py
@@ -13,11 +13,11 @@ logger = logging.getLogger(__name__)
 async def _send_menu(client: Client, message: Message) -> None:
     user = message.from_user
     text = [
-        "**👋 Welcome!**",
+        "<b>👋 Welcome!</b>",
         "I'm a simple moderation bot.",
     ]
     if user:
-        text.append(f"Your ID: `{user.id}`")
+        text.append(f"Your ID: <code>{user.id}</code>")
     me = await client.get_me()
     buttons = InlineKeyboardMarkup(
         [
@@ -34,7 +34,7 @@ async def _send_menu(client: Client, message: Message) -> None:
             ],
         ]
     )
-    await message.reply_text("\n".join(text), reply_markup=buttons, parse_mode="markdown")
+    await message.reply_text("\n".join(text), reply_markup=buttons, parse_mode="html")
 
 
 def init(app: Client) -> None:

--- a/handlers/panel.py
+++ b/handlers/panel.py
@@ -62,12 +62,12 @@ def init(app: Client) -> None:
             await message.reply_photo(
                 photo=BANNER_URL,
                 caption=(
-                    "🔧 **SETTINGS PANEL**\n"
+                    "🔧 <b>SETTINGS PANEL</b>\n"
                     "Select one of the settings that you want to change.\n\n"
-                    "Group: `BOTS ✺ YARD DISCUSSION`"
+                    "Group: <code>BOTS ✺ YARD DISCUSSION</code>"
                 ),
                 reply_markup=SETTINGS_PANEL,
-                parse_mode="markdown",
+                parse_mode="html",
             )
 
     @app.on_callback_query()
@@ -80,6 +80,6 @@ def init(app: Client) -> None:
 
         await query.answer()
         await query.message.edit_text(
-            f"🛠 *You selected:* `{query.data}`\nThat setting's options will be shown soon.",
-            parse_mode="markdown",
+            f"🛠 <i>You selected:</i> <code>{query.data}</code>\nThat setting's options will be shown soon.",
+            parse_mode="html",
         )

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ bot = Client(
     api_id=API_ID,
     api_hash=API_HASH,
     bot_token=BOT_TOKEN,
-    parse_mode="markdown",
+    parse_mode="html",
 )
 
 


### PR DESCRIPTION
## Summary
- switch bot client to HTML parse mode
- convert command responses and logs to HTML formatting
- keep messaging logic the same otherwise

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6866d36e0cfc832992271276f237050b