### PR TITLE
Fix Pyrogram parse mode usage

### DIFF
--- a/handlers/approval.py
+++ b/handlers/approval.py
@@ -23,9 +23,7 @@ def init(app: Client) -> None:
             return
         user_id = message.reply_to_message.from_user.id
         await approve_user(message.chat.id, user_id)
-        await message.reply_text(
-            f"✅ Approved <code>{user_id}</code>", parse_mode="html"
-        )
+        await message.reply_text(f"✅ Approved <code>{user_id}</code>")
 
     @app.on_message(filters.command("unapprove") & filters.group)
     @catch_errors
@@ -38,9 +36,7 @@ def init(app: Client) -> None:
             return
         user_id = message.reply_to_message.from_user.id
         await unapprove_user(message.chat.id, user_id)
-        await message.reply_text(
-            f"❌ Unapproved <code>{user_id}</code>", parse_mode="html"
-        )
+        await message.reply_text(f"❌ Unapproved <code>{user_id}</code>")
 
     @app.on_message(filters.command("viewapproved") & filters.group)
     @catch_errors
@@ -53,4 +49,4 @@ def init(app: Client) -> None:
             await message.reply_text("📭 No approved users.")
             return
         text = "<b>📋 Approved Users:</b>\n" + "\n".join(f"<code>{u}</code>" for u in users)
-        await message.reply_text(text, parse_mode="html")
+        await message.reply_text(text)

--- a/handlers/autodelete.py
+++ b/handlers/autodelete.py
@@ -25,9 +25,7 @@ def init(app: Client) -> None:
             return
         await set_autodelete(message.chat.id, seconds)
         if seconds > 0:
-            await message.reply_text(
-                f"🕒 Auto-delete set to {seconds} seconds.", parse_mode="html"
-            )
+            await message.reply_text(f"🕒 Auto-delete set to {seconds} seconds.")
         else:
             await message.reply_text("❌ Auto-delete disabled.")
 

--- a/handlers/commands.py
+++ b/handlers/commands.py
@@ -28,7 +28,7 @@ def init(app: Client) -> None:
             "/setautodelete <sec> - auto delete messages\n"
             "/start - open control panel"
         )
-        await message.reply_text(help_text, parse_mode="html")
+        await message.reply_text(help_text)
 
     @app.on_message(filters.command("auth"))
     @catch_errors
@@ -39,7 +39,7 @@ def init(app: Client) -> None:
             return
         try:
             member = await client.get_chat_member(message.chat.id, message.from_user.id)
-            await message.reply_text(f"Your status: <code>{member.status}</code>", parse_mode="html")
+            await message.reply_text(f"Your status: <code>{member.status}</code>")
         except Exception as exc:
             logger.warning("auth check failed: %s", exc)
             await message.reply_text("Couldn't check your status.")
@@ -56,5 +56,5 @@ def init(app: Client) -> None:
             "/setautodelete <sec> - auto delete messages\n"
             "/start - open control panel"
         )
-        await query.message.edit_text(help_text, parse_mode="html")
+        await query.message.edit_text(help_text)
 

--- a/handlers/logs.py
+++ b/handlers/logs.py
@@ -43,7 +43,7 @@ async def log_action_tracker(client: Client, chat: Chat, actor: User | None, act
         ])
 
     lines.append("━━━━━━━━━━━━━━━━━━━━━━")
-    await client.send_message(LOG_CHANNEL_ID, "\n".join(lines), parse_mode="html")
+    await client.send_message(LOG_CHANNEL_ID, "\n".join(lines))
 
 async def log_event(client: Client, action: str, source: Chat | User):
     if isinstance(source, Chat):
@@ -58,7 +58,7 @@ async def log_event(client: Client, action: str, source: Chat | User):
         f"{ident}\n"
         f"🕒 <code>{datetime.utcnow().isoformat()}</code>"
     )
-    await client.send_message(LOG_CHANNEL_ID, text, parse_mode="html")
+    await client.send_message(LOG_CHANNEL_ID, text)
 
 
 def init(app: Client) -> None:

--- a/handlers/menu.py
+++ b/handlers/menu.py
@@ -34,7 +34,7 @@ async def _send_menu(client: Client, message: Message) -> None:
             ],
         ]
     )
-    await message.reply_text("\n".join(text), reply_markup=buttons, parse_mode="html")
+    await message.reply_text("\n".join(text), reply_markup=buttons)
 
 
 def init(app: Client) -> None:

--- a/handlers/panel.py
+++ b/handlers/panel.py
@@ -67,7 +67,6 @@ def init(app: Client) -> None:
                     "Group: <code>BOTS ✺ YARD DISCUSSION</code>"
                 ),
                 reply_markup=SETTINGS_PANEL,
-                parse_mode="html",
             )
 
     @app.on_callback_query()
@@ -80,6 +79,5 @@ def init(app: Client) -> None:
 
         await query.answer()
         await query.message.edit_text(
-            f"🛠 <i>You selected:</i> <code>{query.data}</code>\nThat setting's options will be shown soon.",
-            parse_mode="html",
+            f"🛠 <i>You selected:</i> <code>{query.data}</code>\nThat setting's options will be shown soon."
         )

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import logging
 
 from pyrogram import Client, filters, idle
+from pyrogram.enums import ParseMode
 
 from config import API_HASH, API_ID, BOT_TOKEN, MONGO_URI
 from handlers import init_all
@@ -24,7 +25,7 @@ bot = Client(
     api_id=API_ID,
     api_hash=API_HASH,
     bot_token=BOT_TOKEN,
-    parse_mode="html",
+    parse_mode=ParseMode.HTML,
 )
 
 


### PR DESCRIPTION
## Summary
- set ParseMode.HTML globally in the Client constructor
- remove per-message `parse_mode` arguments

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6866d61008d88329a23eacea8eb332fb