### PR TITLE
Fix parse_mode for Pyrogram 2

### DIFF
--- a/handlers/logs.py
+++ b/handlers/logs.py
@@ -3,6 +3,7 @@
 import logging
 from datetime import datetime
 from pyrogram import Client, filters
+from pyrogram.enums import ParseMode
 from pyrogram.types import Chat, User, Message, ChatMemberUpdated
 from config import LOG_CHANNEL_ID
 from utils.errors import catch_errors
@@ -46,7 +47,7 @@ async def log_action_tracker(client: Client, chat: Chat, actor: User | None, act
     await client.send_message(
         LOG_CHANNEL_ID,
         "\n".join(lines),
-        parse_mode="HTML",
+        parse_mode=ParseMode.HTML,
     )
 
 async def log_event(client: Client, action: str, source: Chat | User):
@@ -62,7 +63,7 @@ async def log_event(client: Client, action: str, source: Chat | User):
         f"{ident}\n"
         f"🕒 <code>{datetime.utcnow().isoformat()}</code>"
     )
-    await client.send_message(LOG_CHANNEL_ID, text, parse_mode="HTML")
+    await client.send_message(LOG_CHANNEL_ID, text, parse_mode=ParseMode.HTML)
 
 
 def init(app: Client) -> None:


### PR DESCRIPTION
## Summary
- adjust `send_message()` calls in the logging handler to use `ParseMode.HTML`
- import `ParseMode` in `handlers/logs.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6866dd691df4832997b0b240fe04b5c0