### PR TITLE
Ensure user commands always reply

### DIFF
--- a/handlers/approval.py
+++ b/handlers/approval.py
@@ -17,6 +17,7 @@ def init(app: Client) -> None:
     async def approve_cmd(client: Client, message: Message):
         logger.info("approve command in %s by %s", message.chat.id, message.from_user.id if message.from_user else None)
         if not await is_admin(client, message):
+            await message.reply_text("❌ You must be an admin to use this command.")
             return
         if not message.reply_to_message or not message.reply_to_message.from_user:
             await message.reply_text("Reply to a user to approve.")
@@ -30,6 +31,7 @@ def init(app: Client) -> None:
     async def unapprove_cmd(client: Client, message: Message):
         logger.info("unapprove command in %s by %s", message.chat.id, message.from_user.id if message.from_user else None)
         if not await is_admin(client, message):
+            await message.reply_text("❌ You must be an admin to use this command.")
             return
         if not message.reply_to_message or not message.reply_to_message.from_user:
             await message.reply_text("Reply to a user to unapprove.")
@@ -43,6 +45,7 @@ def init(app: Client) -> None:
     async def view_approved(client: Client, message: Message):
         logger.info("viewapproved command in %s by %s", message.chat.id, message.from_user.id if message.from_user else None)
         if not await is_admin(client, message):
+            await message.reply_text("❌ You must be an admin to use this command.")
             return
         users = await get_approved(message.chat.id)
         if not users:

--- a/handlers/autodelete.py
+++ b/handlers/autodelete.py
@@ -17,6 +17,7 @@ def init(app: Client) -> None:
     async def set_autodel(client: Client, message: Message):
         logger.info("setautodelete command in %s by %s", message.chat.id, message.from_user.id if message.from_user else None)
         if not await is_admin(client, message):
+            await message.reply_text("❌ You must be an admin to use this command.")
             return
         try:
             seconds = int(message.command[1])

--- a/handlers/menu.py
+++ b/handlers/menu.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 async def _send_menu(client: Client, message: Message) -> None:
     user = message.from_user
     text = [
-        "<b>👋 Welcome!</b>",
+        "👋 Welcome! I'm alive and working.",
         "I'm a simple moderation bot.",
     ]
     if user:
@@ -43,6 +43,12 @@ def init(app: Client) -> None:
     async def start_cmd(client: Client, message: Message):
         logger.info("/start from %s", message.from_user.id if message.from_user else None)
         await _send_menu(client, message)
+
+    @app.on_message(filters.command("start") & ~filters.private)
+    @catch_errors
+    async def start_group_cmd(client: Client, message: Message):
+        logger.info("/start in %s", message.chat.id)
+        await message.reply_text("👋 Welcome! I'm alive and working. Please DM me to access the menu.")
 
     @app.on_message(filters.command("menu"))
     @catch_errors

--- a/handlers/panel.py
+++ b/handlers/panel.py
@@ -68,6 +68,8 @@ def init(app: Client) -> None:
                 ),
                 reply_markup=SETTINGS_PANEL,
             )
+        else:
+            await message.reply_text("❌ You must be an admin to open the panel.")
 
     @app.on_callback_query()
     @catch_errors


### PR DESCRIPTION
## Summary
- add group `/start` reply and greet in menu
- clarify admin permission checks for `/approve`, `/unapprove`, `/viewapproved`, `/setautodelete`, and `/panel`
- update welcome text to show the bot is alive

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6866df1253808329871f384ee7c232f4