### PR TITLE
Refactor bot startup and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,4 @@ BANNER_URL=
 UPDATE_CHANNEL_ID=0
 SUPPORT_CHAT_URL=https://t.me/botsyard
 DEVELOPER_URL=https://t.me/oxeign
+LOG_LEVEL=INFO

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Guard
 
-Guard is a simple moderation bot built with Pyrogram. It stores data in a local SQLite database and requires a few environment variables before running. The bot reads these variables from the environment (or a `.env` file) on startup.
+Guard is a modular Telegram bot built with Pyrogram. It stores data in a local SQLite database and automatically initialises the tables on startup. The bot reads its configuration from the environment (or a `.env` file) and runs in polling mode which makes it suitable for platforms such as Render or Railway without any open ports.
 
 ## Required environment variables
 
@@ -9,6 +9,7 @@ Guard is a simple moderation bot built with Pyrogram. It stores data in a local 
 - `API_HASH` – API hash from https://my.telegram.org.
 - `DB_PATH` – *(optional)* path to the SQLite database file. Defaults to `guard.db`.
 - `BANNER_URL` – *(optional)* image URL displayed on the settings panel.
+- `LOG_LEVEL` – *(optional)* logging level, e.g. `INFO` or `DEBUG`.
 
 ## Setup
 
@@ -25,6 +26,7 @@ API_HASH=0123456789abcdef0123456789abcdef
 DB_PATH=guard.db
 # Optional image to display on the settings panel
 BANNER_URL=
+LOG_LEVEL=INFO
 EOF
 ```
 
@@ -63,15 +65,20 @@ docker run --env-file .env guard
 
 ## Usage
 
-The bot offers a few moderation tools:
+The bot offers a set of moderation tools:
 
-- `/approve` and `/unapprove` – manage approved users in a group.
-- `/viewapproved` – list approved users.
+- `/start` or `/menu` – open the inline control panel.
+- `/help` – display available commands.
+- `/ping` – simple health check.
+- `/approve` and `/unapprove` – manage approved users.
 - `/setautodelete <seconds>` – automatically delete messages from non‑admins.
-- `/mute`, `/kick`, `/ban` – basic moderation actions on a replied user.
-- `/start` – open the settings panel in private chat or for group admins.
+- `/biolink [on|off]` – toggle the bio link filter.
+- `/viewapproved` – list approved users.
 
-Only group admins can use these commands.
+Only group admins can use these commands in group chats.
+
+Most commands present inline buttons for quick access to approval actions and
+setting toggles.
 
 
 The bot stores all data in a local SQLite database by default. Set the

--- a/config.py
+++ b/config.py
@@ -10,6 +10,7 @@ BOT_TOKEN = os.getenv("BOT_TOKEN", "")
 API_ID = int(os.getenv("API_ID", "0"))
 API_HASH = os.getenv("API_HASH", "")
 DB_PATH = os.getenv("DB_PATH", "guard.db")
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
 
 _missing = [
     name

--- a/main.py
+++ b/main.py
@@ -3,22 +3,14 @@ import logging
 from pyrogram import Client, filters, idle
 from pyrogram.enums import ParseMode
 
-from config import API_HASH, API_ID, BOT_TOKEN, DB_PATH
-from handlers import (
-    biofilter,
-    approval,
-    commands,
-    menu,
-    panel,
-    message_logger,
-    autodelete,
-)
+from config import API_HASH, API_ID, BOT_TOKEN, DB_PATH, LOG_LEVEL
+from handlers import init_all
 from utils.db import close_db, init_db
 from utils.errors import catch_errors
 
 logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    level=logging.INFO,
+    level=getattr(logging, LOG_LEVEL, logging.INFO),
 )
 logger = logging.getLogger(__name__)
 
@@ -61,16 +53,7 @@ async def fallback_cmd(_, message):
 async def main() -> None:
     logger.info("Initializing database connection")
     await init_db(DB_PATH)
-    for handler in [
-        biofilter,
-        approval,
-        commands,
-        menu,
-        panel,
-        message_logger,
-        autodelete,
-    ]:
-        handler.register(bot)
+    init_all(bot)
     async with bot:
         logger.info("Bot started and waiting for events")
         await idle()


### PR DESCRIPTION
## Summary
- add optional `LOG_LEVEL` setting
- initialise all handlers via `init_all`
- document commands and environment variables

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6866f1f7971c83298d9f66810c3bf305