### PR TITLE
Add /autodelete command

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The bot offers a set of moderation tools:
 - `/help` – display available commands.
 - `/ping` – simple health check.
 - `/approve` and `/unapprove` – manage approved users.
-- `/setautodelete <seconds>` – automatically delete messages from non‑admins.
+- `/autodelete <seconds>` – automatically delete messages from non‑admins (use `/autodelete` alone to view the current delay). `/setautodelete` remains as an alias.
 - `/biolink [on|off]` – toggle the bio link filter.
 - `/viewapproved` – list approved users.
 

--- a/handlers/autodelete.py
+++ b/handlers/autodelete.py
@@ -13,17 +13,26 @@ logger = logging.getLogger(__name__)
 
 
 def register(app: Client) -> None:
-    @app.on_message(filters.command("setautodelete") & filters.group)
+    @app.on_message(filters.command(["setautodelete", "autodelete"]) & filters.group)
     @catch_errors
     async def set_autodel(client: Client, message: Message):
-        logger.info("setautodelete command in %s by %s", message.chat.id, message.from_user.id if message.from_user else None)
+        logger.info(
+            "%s command in %s by %s",
+            message.command[0],
+            message.chat.id,
+            message.from_user.id if message.from_user else None,
+        )
         if not await is_admin(client, message):
             await message.reply_text("❌ You must be an admin to use this command.")
+            return
+        if len(message.command) == 1 and message.command[0] == "autodelete":
+            delay = await get_autodelete(message.chat.id)
+            await message.reply_text(f"Current auto-delete setting: {delay} seconds")
             return
         try:
             seconds = int(message.command[1])
         except (IndexError, ValueError):
-            await message.reply_text("Usage: /setautodelete <seconds>")
+            await message.reply_text("Usage: /autodelete <seconds>")
             return
         await set_autodelete(message.chat.id, seconds)
         if seconds > 0:
@@ -36,6 +45,8 @@ def register(app: Client) -> None:
     async def autodelete_handler(client: Client, message: Message):
         logger.debug("autodelete check in %s", message.chat.id)
         if not (message.text or message.caption):
+            return
+        if message.from_user is None:
             return
         if await is_admin(client, message, message.from_user.id):
             return


### PR DESCRIPTION
## Summary
- implement `/autodelete` command (alias of `/setautodelete`)
- ignore service messages in auto-delete handler
- document new command in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6866f6013fc8832996148e05a7a5d2ed