### PR TITLE
Fix admin checks in private chats

### DIFF
--- a/handlers/commands.py
+++ b/handlers/commands.py
@@ -2,7 +2,7 @@
 
 import logging
 from pyrogram import Client, filters
-from pyrogram.enums import ParseMode
+from pyrogram.enums import ParseMode, ChatType
 from pyrogram.types import Message, CallbackQuery, ChatPermissions
 
 from utils.perms import is_admin
@@ -20,7 +20,7 @@ def register(app: Client) -> None:
     @catch_errors
     async def help_cmd(client: Client, message: Message):
         logger.info("/help from %s", message.chat.id)
-        if message.chat.type != "private":
+        if message.chat.type != ChatType.PRIVATE:
             await message.reply_text("ℹ️ Please DM me for help.")
             return
 
@@ -42,7 +42,7 @@ def register(app: Client) -> None:
     @catch_errors
     async def auth_cmd(client: Client, message: Message):
         logger.info("/auth from %s", message.chat.id)
-        if message.chat.type == "private":
+        if message.chat.type == ChatType.PRIVATE:
             await message.reply_text("This command can only be used in groups.")
             return
         try:

--- a/handlers/menu.py
+++ b/handlers/menu.py
@@ -1,6 +1,6 @@
 import logging
 from pyrogram import Client, filters
-from pyrogram.enums import ParseMode
+from pyrogram.enums import ParseMode, ChatType
 from pyrogram.types import InlineKeyboardButton, InlineKeyboardMarkup, Message, CallbackQuery
 
 from config import SUPPORT_CHAT_URL, DEVELOPER_URL
@@ -53,7 +53,7 @@ def register(app: Client) -> None:
     @catch_errors
     async def start_menu(client: Client, message: Message):
         logger.info("%s in %s", message.command[0], message.chat.id)
-        if message.chat.type != "private" and not await is_admin(client, message):
+        if message.chat.type != ChatType.PRIVATE and not await is_admin(client, message):
             await message.reply_text("❌ You must be an admin to use this command.")
             return
         await send_panel(client, message)

--- a/handlers/panel.py
+++ b/handlers/panel.py
@@ -2,6 +2,7 @@
 
 import logging
 from pyrogram import Client, filters
+from pyrogram.enums import ChatType
 from pyrogram.types import (
     Message,
     InlineKeyboardMarkup,
@@ -58,7 +59,7 @@ def register(app: Client) -> None:
     @catch_errors
     async def open_panel(client: Client, message: Message):
         logger.info("/panel from %s", message.chat.id)
-        if message.chat.type == "private" or await is_admin(client, message):
+        if message.chat.type == ChatType.PRIVATE or await is_admin(client, message):
             await message.reply_photo(
                 photo=BANNER_URL,
                 caption=(

--- a/utils/perms.py
+++ b/utils/perms.py
@@ -3,13 +3,13 @@
 import logging
 from pyrogram import Client
 from pyrogram.types import Message
-from pyrogram.enums import ChatMemberStatus
+from pyrogram.enums import ChatMemberStatus, ChatType
 
 logger = logging.getLogger(__name__)
 
 async def is_admin(client: Client, message: Message, user_id: int | None = None) -> bool:
     """Return ``True`` if the user is an admin of the chat."""
-    if message.chat.type == "private":
+    if message.chat.type == ChatType.PRIVATE:
         return True
 
     user_id = user_id or message.from_user.id


### PR DESCRIPTION
## Summary
- fix `is_admin` logic by using `ChatType.PRIVATE`
- adjust command handlers to use `ChatType.PRIVATE`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6866f955436c83299b4be749462a0ab0