### PR TITLE
Add link filter and edited message autodelete with new /start flow

### DIFF
--- a/config.py
+++ b/config.py
@@ -33,4 +33,4 @@ UPDATE_CHANNEL_ID = int(os.getenv("UPDATE_CHANNEL_ID", "0"))
 SUPPORT_CHAT_URL = os.getenv("SUPPORT_CHAT_URL", "https://t.me/botsyard")
 DEVELOPER_URL = os.getenv("DEVELOPER_URL", "https://t.me/oxeign")
 # Image shown at the top of the settings panel
-BANNER_URL = os.getenv("BANNER_URL", "https://files.catbox.moe/uvqeln.jpg")
+PANEL_IMAGE_URL = os.getenv("PANEL_IMAGE_URL", "https://files.catbox.moe/uvqeln.jpg")

--- a/handlers/general.py
+++ b/handlers/general.py
@@ -2,13 +2,18 @@ import logging
 from pyrogram import Client, filters
 from pyrogram.types import Message
 from utils.errors import catch_errors
-from panel import send_panel
+from panel import send_start, send_control_panel
 
 logger = logging.getLogger(__name__)
 
 
 def register(app: Client) -> None:
-    @app.on_message(filters.command(["start", "help", "menu"]))
+    @app.on_message(filters.command("start"))
     @catch_errors
-    async def show_panel(client: Client, message: Message) -> None:
-        await send_panel(client, message)
+    async def start_cmd(client: Client, message: Message) -> None:
+        await send_start(client, message)
+
+    @app.on_message(filters.command(["help", "menu"]))
+    @catch_errors
+    async def panel_cmd(client: Client, message: Message) -> None:
+        await send_control_panel(client, message)

--- a/handlers/settings.py
+++ b/handlers/settings.py
@@ -86,3 +86,37 @@ def register(app: Client) -> None:
         await set_setting(message.chat.id, "autodelete", "0")
         await set_setting(message.chat.id, "autodelete_interval", "0")
         await message.reply_text("🧹 Auto-delete disabled.", parse_mode=ParseMode.HTML)
+
+    @app.on_message(filters.command("linkfilter") & filters.group)
+    @catch_errors
+    async def cmd_linkfilter(client: Client, message: Message):
+        if not await is_admin(client, message):
+            await message.reply_text("🔒 <b>Admins only.</b>", parse_mode=ParseMode.HTML)
+            return
+        arg = message.command[1].lower() if len(message.command) > 1 else None
+        if arg in {"on", "off"}:
+            state = "1" if arg == "on" else "0"
+            await set_setting(message.chat.id, "linkfilter", state)
+        else:
+            state = await toggle_setting(message.chat.id, "linkfilter")
+        await message.reply_text(
+            f"🔗 Link filter {'enabled ✅' if state == '1' else 'disabled ❌'}",
+            parse_mode=ParseMode.HTML,
+        )
+
+    @app.on_message(filters.command("autodeleteedited") & filters.group)
+    @catch_errors
+    async def cmd_autodeleteedited(client: Client, message: Message):
+        if not await is_admin(client, message):
+            await message.reply_text("🔒 <b>Admins only.</b>", parse_mode=ParseMode.HTML)
+            return
+        arg = message.command[1].lower() if len(message.command) > 1 else None
+        if arg in {"on", "off"}:
+            state = "1" if arg == "on" else "0"
+            await set_setting(message.chat.id, "editmode", state)
+        else:
+            state = await toggle_setting(message.chat.id, "editmode")
+        await message.reply_text(
+            f"📝 Edited delete {'enabled ✅' if state == '1' else 'disabled ❌'}",
+            parse_mode=ParseMode.HTML,
+        )

--- a/oxygenbot.py
+++ b/oxygenbot.py
@@ -23,7 +23,7 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 BOT_USERNAME = os.getenv("BOT_USERNAME", "OxeignBot")
-BANNER_URL = os.getenv("BANNER_URL")
+PANEL_IMAGE_URL = os.getenv("PANEL_IMAGE_URL")
 SUPPORT_CHAT_URL = os.getenv("SUPPORT_CHAT_URL", "https://t.me/botsyard")
 DEVELOPER_URL = os.getenv("DEVELOPER_URL", "https://t.me/oxeign")
 

--- a/panel.py
+++ b/panel.py
@@ -1,5 +1,6 @@
 import os
 import logging
+from contextlib import suppress
 from time import perf_counter
 from pyrogram import Client
 from pyrogram.enums import ParseMode, ChatType
@@ -10,21 +11,44 @@ from utils.perms import is_admin
 
 logger = logging.getLogger(__name__)
 
-BANNER_URL = os.getenv("BANNER_URL")
+PANEL_IMAGE_URL = os.getenv("PANEL_IMAGE_URL")
 SUPPORT_CHAT_URL = os.getenv("SUPPORT_CHAT_URL", "https://t.me/botsyard")
 DEVELOPER_URL = os.getenv("DEVELOPER_URL", "https://t.me/oxeign")
 BOT_USERNAME = os.getenv("BOT_USERNAME", "OxeignBot")
 
 
+async def build_start_panel(is_admin_user: bool) -> InlineKeyboardMarkup:
+    buttons = [
+        [
+            InlineKeyboardButton(
+                "➕ Add Me to Group",
+                url=f"https://t.me/{BOT_USERNAME}?startgroup=true",
+            ),
+            InlineKeyboardButton("📚 Help & Commands", callback_data="cb_help_start"),
+        ],
+        [
+            InlineKeyboardButton("🛟 Support", url=SUPPORT_CHAT_URL),
+            InlineKeyboardButton("👨\u200d💻 Developer", url=DEVELOPER_URL),
+        ],
+    ]
+    if is_admin_user:
+        buttons.append([InlineKeyboardButton("🧰 Control Panel", callback_data="cb_open_panel")])
+    return InlineKeyboardMarkup(buttons)
+
+
 async def build_group_panel(chat_id: int, client: Client) -> tuple[str, InlineKeyboardMarkup]:
     bio_status = await get_setting(chat_id, "biolink", "0") == "1"
+    link_status = await get_setting(chat_id, "linkfilter", "0") == "1"
     delete_enabled = await get_setting(chat_id, "autodelete", "0") == "1"
+    edit_status = await get_setting(chat_id, "editmode", "0") == "1"
     delete_interval = await get_setting(chat_id, "autodelete_interval", "0")
 
     caption = (
         "<b>🛡️ Group Guard Panel</b>\n\n"
         f"🔗 Bio Filter: {'<b>✅ ON</b>' if bio_status else '<b>❌ OFF</b>'}\n"
-        f"🗑️ Auto Delete: {'<b>✅ ' + delete_interval + 's</b>' if delete_enabled and delete_interval else '<b>❌ OFF</b>'}"
+        f"🌐 Link Filter: {'<b>✅ ON</b>' if link_status else '<b>❌ OFF</b>'}\n"
+        f"🗑️ Auto Delete: {'<b>✅ ' + delete_interval + 's</b>' if delete_enabled and delete_interval else '<b>❌ OFF</b>'}\n"
+        f"📝 Edit Delete: {'<b>✅ 15m</b>' if edit_status else '<b>❌ OFF</b>'}"
     )
 
     buttons = [
@@ -37,7 +61,11 @@ async def build_group_panel(chat_id: int, client: Client) -> tuple[str, InlineKe
             InlineKeyboardButton("🔗 Bio Filter", callback_data="cb_toggle_biolink"),
         ],
         [
-            InlineKeyboardButton("📖 Help", callback_data="cb_help"),
+            InlineKeyboardButton("🔗 Link Filter", callback_data="cb_toggle_linkfilter"),
+            InlineKeyboardButton("📝 Edit Delete", callback_data="cb_toggle_editmode"),
+        ],
+        [
+            InlineKeyboardButton("📖 Help", callback_data="cb_help_panel"),
             InlineKeyboardButton("📡 Ping", callback_data="cb_ping"),
         ],
         [
@@ -55,7 +83,7 @@ async def build_private_panel() -> tuple[str, InlineKeyboardMarkup]:
     )
     buttons = [
         [
-            InlineKeyboardButton("📖 Help", callback_data="cb_help"),
+            InlineKeyboardButton("📖 Help", callback_data="cb_help_start"),
             InlineKeyboardButton("💬 Support", url=SUPPORT_CHAT_URL),
         ],
         [
@@ -66,17 +94,28 @@ async def build_private_panel() -> tuple[str, InlineKeyboardMarkup]:
     return caption, InlineKeyboardMarkup(buttons)
 
 
-async def send_panel(client: Client, message: Message) -> None:
+async def send_start(client: Client, message: Message) -> None:
+    is_admin_user = False
+    if message.chat.type != ChatType.PRIVATE:
+        is_admin_user = await is_admin(client, message)
+    markup = await build_start_panel(is_admin_user)
+    if PANEL_IMAGE_URL:
+        with suppress(Exception):
+            await client.send_photo(message.chat.id, PANEL_IMAGE_URL)
+    await message.reply_text("Choose an option:", reply_markup=markup)
+
+
+async def send_control_panel(client: Client, message: Message) -> None:
     if message.chat.type == ChatType.PRIVATE:
         caption, markup = await build_private_panel()
     else:
         caption, markup = await build_group_panel(message.chat.id, client)
 
     try:
-        if BANNER_URL:
+        if PANEL_IMAGE_URL:
             await client.send_photo(
                 chat_id=message.chat.id,
-                photo=BANNER_URL,
+                photo=PANEL_IMAGE_URL,
                 caption=caption,
                 reply_markup=markup,
                 parse_mode=ParseMode.HTML,


### PR DESCRIPTION
## Summary
- support new `PANEL_IMAGE_URL` env var
- redesign `/start` flow with banner image and option buttons
- add rich control panel showing toggle states for all filters
- implement `/linkfilter` and `/autodeleteedited` commands
- extend callback handlers for new toggles and help menu

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6867a0e6c5488329b56fa138517a305e