### PR TITLE
Fix import conflict in handlers

### DIFF
--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -1,9 +1,9 @@
 """Register all bot handlers."""
 
 from pyrogram import Client
-import logging
+import logging as py_logging
 
-logger = logging.getLogger(__name__)
+logger = py_logging.getLogger(__name__)
 
 # Explicit imports to avoid shadowing
 from . import (


### PR DESCRIPTION
## Summary
- avoid clashing with stdlib logging module by aliasing imports

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6867c40889f483299854fc42eabd6561