### PR TITLE
Improve setup docs and env var error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,13 @@ OxeignBot is a modular Telegram moderation bot built with [Pyrogram](https://doc
    ```bash
    pip install -r requirements.txt
    ```
-2. Create a `.env` file based on `.env.example` and fill in your API credentials.
-   Make sure `MONGO_URI` points to a reachable MongoDB instance.
+2. Copy `.env.example` to `.env` and fill in **all** required variables (`API_ID`,
+   `API_HASH`, `BOT_TOKEN`). If any of these are missing the bot will exit with a
+   clear error message. Ensure `MONGO_URI` points to a reachable MongoDB
+   instance.
 3. Run the bot
    ```bash
-   python oxeignbot.py
+   python main.py
    ```
 
 ## License

--- a/config.py
+++ b/config.py
@@ -25,8 +25,12 @@ _missing = [
     if not value
 ]
 if _missing:
-    logger.error("Missing required env vars: %s", ", ".join(_missing))
-    raise RuntimeError("Required environment variables are missing")
+    missing_str = ", ".join(_missing)
+    logger.error("Missing required env vars: %s", missing_str)
+    raise RuntimeError(
+        "Missing required environment variables: "
+        f"{missing_str}. Create a .env file from .env.example and set them."
+    )
 
 # Optional configuration
 UPDATE_CHANNEL_ID = int(os.getenv("UPDATE_CHANNEL_ID", "0"))


### PR DESCRIPTION
## Summary
- clarify setup instructions in README
- improve configuration error message for missing environment variables

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6867c662d0c083299a37dcdeb6e7bab6