### PR TITLE
Fix handler registration and keep bot running

### DIFF
--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -19,7 +19,7 @@ logger = py_logging.getLogger(__name__)
 
 def register_all(app: Client) -> None:
     """Register each handler module with the provided ``Client``."""
-    print("✅ Registering all handlers...")
+    logger.info("Registering handlers")
 
     ping.register(app)
     admin.register(app)

--- a/main.py
+++ b/main.py
@@ -41,6 +41,7 @@ logger.info(
 )
 
 # Initialize Pyrogram Client
+
 bot = Client(
     "moderation-bot",
     api_id=API_ID,
@@ -82,13 +83,15 @@ async def main() -> None:
 
     logger.info("🤖 Fetching bot details from Telegram...")
     try:
-        async with bot:
-            me = await bot.get_me()
-            logger.info("Logged in as %s (@%s)", me.id, me.username)
-            logger.info("✅ Bot is up and running. Waiting for events...")
-            await idle()
+        await bot.start()
+        me = await bot.get_me()
+        logger.info("Logged in as %s (@%s)", me.id, me.username)
+        logger.info("✅ Bot is up and running. Waiting for events...")
+        await idle()
     except Exception as exc:  # noqa: BLE001
         logger.exception("Bot runtime error: %s", exc)
+    finally:
+        await bot.stop()
 
     logger.info("🔒 Closing DB connection...")
     await close_db()


### PR DESCRIPTION
## Summary
- use logger when registering handlers
- start Client explicitly and call `idle()` so events fire

## Testing
- `python -m py_compile main.py handlers/*.py utils/*.py panel.py web.py oxygenbot.py`

------
https://chatgpt.com/codex/tasks/task_b_6867cd348db48329b14d1f1fc63e5f23