### PR TITLE
Implement toggles for moderation features

### DIFF
--- a/handlers/callbacks.py
+++ b/handlers/callbacks.py
@@ -15,7 +15,7 @@ COMMANDS = [
     ("✅ /approve", "Approve a user"),
     ("❌ /unapprove", "Revoke approval"),
     ("📋 /viewapproved", "List approved users"),
-    ("🕒 /setautodelete", "Set auto delete time"),
+    ("🕒 /autodelete <seconds>", "Set auto delete time"),
     ("🔄 /autodeleteon | /autodeleteoff", "Toggle auto delete"),
     ("📝 /autodeleteedited on | off", "Delete edited messages"),
     ("🤐 /mute", "Mute user"),


### PR DESCRIPTION
## Summary
- update callback command list
- add admin commands to toggle `biolink`, `linkfilter` and `editmode`
- implement `/autodelete` and `/autodeleteoff` commands

## Testing
- `python -m py_compile handlers/admin.py handlers/callbacks.py handlers/filters.py handlers/general.py handlers/logging.py handlers/ping.py`

------
https://chatgpt.com/codex/tasks/task_b_68680ecc9df083298db88d054293deac