### PR TITLE
Refactor auto-delete and menus

### DIFF
--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -197,37 +197,28 @@ def register(app: Client) -> None:
             parse_mode=ParseMode.HTML,
         )
 
-    @app.on_message(filters.command("autodeleteoff") & filters.group)
-    @catch_errors
-    async def autodelete_off_cmd(client: Client, message: Message):
-        if not await _require_admin(message):
-            return
-        await set_setting(message.chat.id, "autodelete", "0")
-        await set_setting(message.chat.id, "autodelete_interval", "0")
-        await message.reply_text("🧹 <b>Auto delete disabled.</b>", parse_mode=ParseMode.HTML)
 
-    @app.on_message(filters.command("autodelete") & filters.group)
+    @app.on_message(filters.command("setautodelete") & filters.group)
     @catch_errors
-    async def autodelete_cmd(client: Client, message: Message):
+    async def set_autodelete_cmd(client: Client, message: Message):
         if not await _require_admin(message):
             return
-        if len(message.command) < 2:
+
+        seconds = 0
+        if len(message.command) > 1:
+            try:
+                seconds = int(message.command[1])
+                if seconds < 0:
+                    raise ValueError
+            except ValueError:
+                await message.reply_text("❗ Provide a valid number of seconds.", parse_mode=ParseMode.HTML)
+                return
+
+        await set_setting(message.chat.id, "autodelete_interval", str(seconds))
+        if seconds > 0:
             await message.reply_text(
-                "❗ <b>Usage:</b> <code>/autodelete &lt;seconds&gt;</code>",
+                f"🧹 <b>Auto delete set to {seconds}s.</b>",
                 parse_mode=ParseMode.HTML,
             )
-            return
-        try:
-            seconds = int(message.command[1])
-            if seconds <= 0:
-                raise ValueError
-        except ValueError:
-            await message.reply_text("❗ Provide a valid number of seconds.", parse_mode=ParseMode.HTML)
-            return
-
-        await set_setting(message.chat.id, "autodelete", "1")
-        await set_setting(message.chat.id, "autodelete_interval", str(seconds))
-        await message.reply_text(
-            f"🧹 <b>Auto delete enabled for {seconds}s.</b>",
-            parse_mode=ParseMode.HTML,
-        )
+        else:
+            await message.reply_text("🧹 <b>Auto delete disabled.</b>", parse_mode=ParseMode.HTML)

--- a/handlers/general.py
+++ b/handlers/general.py
@@ -20,7 +20,7 @@ def register(app: Client) -> None:
         logger.info(f"[START] from user {message.from_user.id}")
         await send_start(client, message)
 
-    @app.on_message(filters.command(["help", "menu"]) & (filters.private | filters.group))
+    @app.on_message(filters.command(["help", "menu", "menuu"]) & (filters.private | filters.group))
     @catch_errors
     async def panel_cmd(client: Client, message: Message) -> None:
         """

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,3 +1,3 @@
-from . import db, errors, perms, webhook
+from . import db, errors, perms, webhook, messages
 
-__all__ = ["db", "errors", "perms", "webhook"]
+__all__ = ["db", "errors", "perms", "webhook", "messages"]

--- a/utils/messages.py
+++ b/utils/messages.py
@@ -1,0 +1,13 @@
+from pyrogram.types import Message
+
+async def safe_edit_message(message: Message, *, text: str | None = None, caption: str | None = None, **kwargs) -> None:
+    """Edit a message only if content differs to avoid MESSAGE_NOT_MODIFIED."""
+    if text is not None:
+        if message.text == text:
+            return
+        await message.edit_text(text, **kwargs)
+    elif caption is not None:
+        if message.caption == caption:
+            return
+        await message.edit_caption(caption, **kwargs)
+


### PR DESCRIPTION
## Summary
- add helper to safely edit messages
- overhaul auto-delete with unified `/setautodelete` command
- always clean edited messages with 15‑minute fallback
- improve control panel buttons and include auto-delete status
- fix callback updates to avoid `MESSAGE_NOT_MODIFIED`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68681be415588329bc3c161cdeef001c