### PR TITLE
Fix auto-delete and help panel

### DIFF
--- a/handlers/callbacks.py
+++ b/handlers/callbacks.py
@@ -1,4 +1,5 @@
 import logging
+from contextlib import suppress
 from time import perf_counter
 from pyrogram import Client, filters
 from pyrogram.enums import ParseMode
@@ -51,6 +52,11 @@ def register(app: Client) -> None:
                 reply_markup=markup,
                 parse_mode=ParseMode.HTML,
             )
+
+        elif data == "cb_close":
+            await query.answer()
+            with suppress(Exception):
+                await query.message.delete()
 
         elif data == "cb_start":
             await query.answer()


### PR DESCRIPTION
## Summary
- improve start panel generation and add Back button support
- use schedule_auto_delete helper for reliable message deletion
- correct link detection regex
- add callback to close help panel

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68682115c77c8329a53420363a55adbf