### PR TITLE
Fix /help panel and improve auto-delete

### DIFF
--- a/handlers/general.py
+++ b/handlers/general.py
@@ -29,7 +29,10 @@ def register(app: Client) -> None:
         """
         source = "private" if message.chat.type == "private" else f"group {message.chat.id}"
         logger.info(f"[HELP/MENU] triggered from {source}")
-        await send_control_panel(client, message)
+        if message.chat.type == "private":
+            await send_start(client, message)
+        else:
+            await send_control_panel(client, message)
 
     @app.on_message(filters.command("commands") & (filters.private | filters.group))
     @catch_errors

--- a/utils/messages.py
+++ b/utils/messages.py
@@ -1,13 +1,32 @@
+import logging
 from pyrogram.types import Message
+
+logger = logging.getLogger(__name__)
 
 async def safe_edit_message(message: Message, *, text: str | None = None, caption: str | None = None, **kwargs) -> None:
     """Edit a message only if content differs to avoid MESSAGE_NOT_MODIFIED."""
     if text is not None:
         if message.text == text:
             return
-        await message.edit_text(text, **kwargs)
+        try:
+            await message.edit_text(text, **kwargs)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Failed to edit message %s in %s: %s",
+                message.id,
+                message.chat.id,
+                exc,
+            )
     elif caption is not None:
         if message.caption == caption:
             return
-        await message.edit_caption(caption, **kwargs)
+        try:
+            await message.edit_caption(caption, **kwargs)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Failed to edit caption for %s in %s: %s",
+                message.id,
+                message.chat.id,
+                exc,
+            )
 


### PR DESCRIPTION
## Summary
- show start panel in private for /help and /menu
- expand group control panel with working toggle buttons
- improve auto-delete logic and add edit clean-up timer
- improve link detection regex
- add logging for message edit errors

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6868255259208329bff07da9c594f9dc