### PR TITLE
Fix imports in bot handler initializer

### DIFF
--- a/oxeign/swagger/bots/bots_handlers/bots_handlers_init.py
+++ b/oxeign/swagger/bots/bots_handlers/bots_handlers_init.py
@@ -2,14 +2,19 @@
 
 from pyrogram import Client
 
+# Import the actual handler modules. The file names use the
+# ``bots_`` prefix, so import them explicitly rather than relying on
+# implicit names that don't exist. Without these explicit imports the
+# application fails to start with ``ImportError`` because modules like
+# ``admin`` or ``callbacks`` are not found.
 from . import (
-    admin,
-    callbacks,
-    filters as msg_filters,
-    general,
-    logging as msg_logging,
-    ping,
-    settings,
+    bots_admin as admin,
+    bots_callbacks as callbacks,
+    bots_filters as msg_filters,
+    bots_general as general,
+    bots_logging as msg_logging,
+    bots_ping as ping,
+    bots_settings as settings,
 )
 
 


### PR DESCRIPTION
## Summary
- fix module names in bots_handlers_init to match actual file names

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_b_68683f6ac3088329ab1ba4d7b548361b