### PR TITLE
Fix imports in bot handlers

### DIFF
--- a/oxeign/swagger/bots/bots_handlers/bots_callbacks.py
+++ b/oxeign/swagger/bots/bots_handlers/bots_callbacks.py
@@ -14,7 +14,7 @@ from utils.errors import catch_errors
 from utils.perms import is_admin
 from utils.db import toggle_setting
 from utils.messages import safe_edit_message
-from .settings import (
+from .bots_settings import (
     build_group_panel,
     build_start_panel,
     get_help_keyboard,

--- a/oxeign/swagger/bots/bots_handlers/bots_general.py
+++ b/oxeign/swagger/bots/bots_handlers/bots_general.py
@@ -4,7 +4,7 @@ from pyrogram.enums import ParseMode
 from pyrogram.types import Message
 from .commands import COMMANDS
 from utils.errors import catch_errors
-from .settings import send_start, send_control_panel
+from .bots_settings import send_start, send_control_panel
 
 logger = logging.getLogger(__name__)
 

--- a/oxeign/swagger/bots/bots_handlers/bots_handlers_init.py
+++ b/oxeign/swagger/bots/bots_handlers/bots_handlers_init.py
@@ -2,14 +2,19 @@
 
 from pyrogram import Client
 
+# Import the actual handler modules. The file names use the
+# ``bots_`` prefix, so import them explicitly rather than relying on
+# implicit names that don't exist. Without these explicit imports the
+# application fails to start with ``ImportError`` because modules like
+# ``admin`` or ``callbacks`` are not found.
 from . import (
-    admin,
-    callbacks,
-    filters as msg_filters,
-    general,
-    logging as msg_logging,
-    ping,
-    settings,
+    bots_admin as admin,
+    bots_callbacks as callbacks,
+    bots_filters as msg_filters,
+    bots_general as general,
+    bots_logging as msg_logging,
+    bots_ping as ping,
+    bots_settings as settings,
 )
 
 


### PR DESCRIPTION
## Summary
- update callbacks and general modules to import `bots_settings`

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_b_68683f6ac3088329ab1ba4d7b548361b