### PR TITLE
Fix import errors for command list

### DIFF
--- a/oxeign/swagger/bots/bots_handlers/bots_callbacks.py
+++ b/oxeign/swagger/bots/bots_handlers/bots_callbacks.py
@@ -19,7 +19,7 @@ from .bots_settings import (
     build_start_panel,
     get_help_keyboard,
 )
-from .commands import COMMANDS
+from .bots_commands import COMMANDS
 
 logger = logging.getLogger(__name__)
 

--- a/oxeign/swagger/bots/bots_handlers/bots_general.py
+++ b/oxeign/swagger/bots/bots_handlers/bots_general.py
@@ -2,7 +2,7 @@ import logging
 from pyrogram import Client, filters
 from pyrogram.enums import ParseMode
 from pyrogram.types import Message
-from .commands import COMMANDS
+from .bots_commands import COMMANDS
 from utils.errors import catch_errors
 from .bots_settings import send_start, send_control_panel
 

--- a/oxeign/swagger/bots/bots_handlers/bots_settings.py
+++ b/oxeign/swagger/bots/bots_handlers/bots_settings.py
@@ -14,7 +14,7 @@ from utils.perms import is_admin
 from utils.db import get_setting
 from utils.messages import safe_edit_message
 from config import SUPPORT_CHAT_URL, DEVELOPER_URL
-from .commands import COMMANDS
+from .bots_commands import COMMANDS
 
 PANEL_IMAGE_URL = os.getenv("PANEL_IMAGE_URL", "https://files.catbox.moe/uvqeln.jpg")
 


### PR DESCRIPTION
## Summary
- correct import path to `bots_commands` module

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68684196dcd88329b7df37fd1a8469af