### PR TITLE
Fix BioFilter toggle

### DIFF
--- a/oxeign/swagger/bots/bots_handlers/bots_admin.py
+++ b/oxeign/swagger/bots/bots_handlers/bots_admin.py
@@ -14,6 +14,7 @@ from utils.db import (
     set_approval_mode,
     get_approval_mode,
     set_setting,
+    set_bio_filter,
 )
 
 logger = logging.getLogger(__name__)
@@ -155,7 +156,7 @@ def register(app: Client) -> None:
         if state is None:
             await message.reply_text("❗ <b>Usage:</b> <code>/biolink on|off</code>", parse_mode=ParseMode.HTML)
             return
-        await set_setting(message.chat.id, "biolink", state)
+        await set_bio_filter(message.chat.id, state == "1")
         await message.reply_text(
             f"🌐 <b>Bio link filter {'ENABLED ✅' if state == '1' else 'DISABLED ❌'}</b>",
             parse_mode=ParseMode.HTML,

--- a/oxeign/swagger/bots/bots_handlers/bots_callbacks.py
+++ b/oxeign/swagger/bots/bots_handlers/bots_callbacks.py
@@ -12,7 +12,7 @@ from pyrogram.types import (
 
 from utils.errors import catch_errors
 from utils.perms import is_admin
-from utils.db import toggle_setting
+from utils.db import toggle_setting, toggle_bio_filter
 from utils.messages import safe_edit_message
 from .bots_settings import (
     build_group_panel,
@@ -67,22 +67,33 @@ def register(app: Client) -> None:
         # Toggle Settings
         elif data.startswith("cb_toggle_"):
             feature_map = {
-                "cb_toggle_biolink": "biolink",
                 "cb_toggle_linkfilter": "linkfilter",
                 "cb_toggle_editmode": "editmode",
             }
-            feature = feature_map.get(data)
-            if not feature:
-                await query.answer("❌ Unknown feature.", show_alert=True)
-                return
 
-            if not await is_admin(client, query.message, user_id):
-                await query.answer("🔒 Admins only!", show_alert=True)
-                return
+            if data == "cb_toggle_biolink":
+                if not await is_admin(client, query.message, user_id):
+                    await query.answer("🔒 Admins only!", show_alert=True)
+                    return
+                state = await toggle_bio_filter(chat_id)
+                await query.answer(
+                    f"Bio Filter is now {'ON ✅' if state else 'OFF ❌'}"
+                )
+            else:
+                feature = feature_map.get(data)
+                if not feature:
+                    await query.answer("❌ Unknown feature.", show_alert=True)
+                    return
 
-            state = await toggle_setting(chat_id, feature)
-            label = feature.replace("filter", " Filter").title()
-            await query.answer(f"{label} is now {'ON ✅' if state == '1' else 'OFF ❌'}")
+                if not await is_admin(client, query.message, user_id):
+                    await query.answer("🔒 Admins only!", show_alert=True)
+                    return
+
+                state = await toggle_setting(chat_id, feature)
+                label = feature.replace("filter", " Filter").title()
+                await query.answer(
+                    f"{label} is now {'ON ✅' if state == '1' else 'OFF ❌'}"
+                )
 
             caption, markup = await build_group_panel(chat_id, client)
             await safe_edit_message(query.message, text=caption, reply_markup=markup, parse_mode=ParseMode.HTML)

--- a/oxeign/swagger/bots/bots_handlers/bots_settings.py
+++ b/oxeign/swagger/bots/bots_handlers/bots_settings.py
@@ -11,7 +11,7 @@ import os
 from html import escape
 
 from utils.perms import is_admin
-from utils.db import get_setting
+from utils.db import get_setting, get_bio_filter
 from utils.messages import safe_edit_message
 from config import SUPPORT_CHAT_URL, DEVELOPER_URL
 from .bots_commands import COMMANDS
@@ -204,7 +204,7 @@ async def build_group_panel(chat_id: int, client: Client) -> tuple[str, InlineKe
 
     interval = int(await get_setting(chat_id, "autodelete_interval", "0"))
     ad_status = f"{interval}s" if interval > 0 else "OFF"
-    biolink = await get_setting(chat_id, "biolink", "0") == "1"
+    biolink = await get_bio_filter(chat_id)
     linkfilter = await get_setting(chat_id, "linkfilter", "0") == "1"
     editmode = await get_setting(chat_id, "editmode", "0") == "1"
 


### PR DESCRIPTION
## Summary
- connect `/biolink` command and inline toggle to proper setting
- display BioFilter status using same key as filter logic

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6868450ca8548329a2aa034f8dbc3f72