### PR TITLE
Remove toggle buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,5 @@ Use `/start` in private chat to see the welcome panel with:
 - **📘 Commands** – view admin commands and access module help.
 - **⚙️ Settings** – open the group control panel if used in a group.
 
-Each toggle button updates instantly and only admins may change them. Support and developer buttons open the URLs you set in `.env`.
+Use the provided commands to enable or disable features. Support and developer buttons open the URLs you set in `.env`.
+Send `/start`, `/menu` or `/help` in a group to open the control panel.

--- a/oxeign/swagger/bots/bots_handlers/bots_callbacks.py
+++ b/oxeign/swagger/bots/bots_handlers/bots_callbacks.py
@@ -64,39 +64,12 @@ def register(app: Client) -> None:
                 caption, markup = await build_group_panel(chat_id, client)
                 await safe_edit_message(query.message, text=caption, reply_markup=markup, parse_mode=ParseMode.HTML)
 
-        # Toggle Settings
+        # Toggle Settings (disabled)
         elif data.startswith("cb_toggle_"):
-            feature_map = {
-                "cb_toggle_linkfilter": "linkfilter",
-                "cb_toggle_editmode": "editmode",
-            }
-
-            if data == "cb_toggle_biolink":
-                if not await is_admin(client, query.message, user_id):
-                    await query.answer("🔒 Admins only!", show_alert=True)
-                    return
-                state = await toggle_bio_filter(chat_id)
-                await query.answer(
-                    f"Bio Filter is now {'ON ✅' if state else 'OFF ❌'}"
-                )
-            else:
-                feature = feature_map.get(data)
-                if not feature:
-                    await query.answer("❌ Unknown feature.", show_alert=True)
-                    return
-
-                if not await is_admin(client, query.message, user_id):
-                    await query.answer("🔒 Admins only!", show_alert=True)
-                    return
-
-                state = await toggle_setting(chat_id, feature)
-                label = feature.replace("filter", " Filter").title()
-                await query.answer(
-                    f"{label} is now {'ON ✅' if state == '1' else 'OFF ❌'}"
-                )
-
-            caption, markup = await build_group_panel(chat_id, client)
-            await safe_edit_message(query.message, text=caption, reply_markup=markup, parse_mode=ParseMode.HTML)
+            await query.answer(
+                "⚠️ Toggle buttons have been removed. Use commands instead.",
+                show_alert=True,
+            )
 
         # Quick Guide Commands
         elif data == "cb_approve":

--- a/oxeign/swagger/bots/bots_handlers/bots_settings.py
+++ b/oxeign/swagger/bots/bots_handlers/bots_settings.py
@@ -73,11 +73,8 @@ def register(app: Client):
     # One panel for all command triggers
     @app.on_message(filters.command(["start", "help", "menu"]))
     async def show_start_panel(client: Client, message: Message):
-        cmd = message.command[0].lower()
+        """Display the control panel or welcome panel based on chat type."""
         if message.chat.type == "private":
-            await send_start(client, message)
-            return
-        if cmd == "start":
             await send_start(client, message)
         else:
             await send_control_panel(client, message)
@@ -200,7 +197,7 @@ def register(app: Client):
 
 
 async def build_group_panel(chat_id: int, client: Client) -> tuple[str, InlineKeyboardMarkup]:
-    """Return caption and keyboard for the group control panel with toggles."""
+    """Return caption and keyboard for the group control panel."""
 
     interval = int(await get_setting(chat_id, "autodelete_interval", "0"))
     ad_status = f"{interval}s" if interval > 0 else "OFF"
@@ -216,24 +213,9 @@ async def build_group_panel(chat_id: int, client: Client) -> tuple[str, InlineKe
         f"✏️ EditMode: <b>{'ON ✅' if editmode else 'OFF ❌'}</b>"
     )
 
+    # Toggle buttons removed; only navigation buttons remain
     markup = InlineKeyboardMarkup(
         [
-            [
-                InlineKeyboardButton(
-                    f"BioFilter {'✅' if biolink else '❌'}",
-                    callback_data="cb_toggle_biolink",
-                ),
-                InlineKeyboardButton(
-                    f"LinkFilter {'✅' if linkfilter else '❌'}",
-                    callback_data="cb_toggle_linkfilter",
-                ),
-            ],
-            [
-                InlineKeyboardButton(
-                    f"EditMode {'✅' if editmode else '❌'}",
-                    callback_data="cb_toggle_editmode",
-                )
-            ],
             [InlineKeyboardButton("🔙 Back", callback_data="cb_start")],
             [InlineKeyboardButton("📘 Commands", callback_data="cb_help_panel")],
         ]

--- a/oxeign/swagger/yard/yard_README.md
+++ b/oxeign/swagger/yard/yard_README.md
@@ -56,4 +56,5 @@ Use `/start` in private chat to see the welcome panel with:
 - **📘 Commands** – view admin commands and access module help.
 - **⚙️ Settings** – open the group control panel if used in a group.
 
-Each toggle button updates instantly and only admins may change them. Support and developer buttons open the URLs you set in `.env`.
+Use the provided commands to enable or disable features. Support and developer buttons open the URLs you set in `.env`.
+Send `/start`, `/menu` or `/help` in a group to open the control panel.


### PR DESCRIPTION
## Summary
- disable inline toggle system
- remove toggle buttons from callback logic
- remove toggle button markup
- update documentation to describe command usage instead of toggles
- show group panel for `/start`, `/menu` and `/help` commands in groups

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_6868482a3f1483299d672655a48c9999