### PR TITLE
Fix start panel callbacks

### DIFF
--- a/oxeign/swagger/bots/bots_handlers/bots_settings.py
+++ b/oxeign/swagger/bots/bots_handlers/bots_settings.py
@@ -30,9 +30,9 @@ async def build_start_panel(
 
     buttons = [[InlineKeyboardButton("📘 Commands", callback_data="cb_help_start")]]
     if is_admin:
-        buttons.insert(0, [InlineKeyboardButton("⚙️ Settings", callback_data="cb_open_panel")])
+        buttons.insert(0, [InlineKeyboardButton("⚙️ Settings", callback_data="cb_start")])
     if include_back:
-        buttons.append([InlineKeyboardButton("🔙 Back", callback_data="cb_close")])
+        buttons.append([InlineKeyboardButton("🔙 Back", callback_data="cb_back_panel")])
     return InlineKeyboardMarkup(buttons)
 
 


### PR DESCRIPTION
## Summary
- fix inline keyboard callback data for start panel

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6868ae69cfa08329a1026a988f27b2b3