### PR TITLE
Refine moderation boolean checks

### DIFF
--- a/oxeign/swagger/bots/bots_handlers/bots_admin.py
+++ b/oxeign/swagger/bots/bots_handlers/bots_admin.py
@@ -9,10 +9,8 @@ from utils.db import (
     approve_user,
     unapprove_user,
     get_approved,
-    is_approved,
     toggle_approval_mode,
     set_approval_mode,
-    get_approval_mode,
     set_setting,
     set_bio_filter,
 )
@@ -26,7 +24,7 @@ def register(app: Client) -> None:
         if message.chat.type not in {"group", "supergroup"}:
             await message.reply_text("❗ Group-only command.", parse_mode=ParseMode.HTML)
             return
-        if not await is_admin(app, message):
+        if not bool(await is_admin(app, message)):
             await message.reply_text("🔒 <b>Admins only.</b>", parse_mode=ParseMode.HTML)
             return
         if not message.reply_to_message or not message.reply_to_message.from_user:
@@ -49,7 +47,7 @@ def register(app: Client) -> None:
 
     async def require_admin_reply(message: Message, action: str):
         """Ensure command is by admin and used as a reply."""
-        if not await is_admin(app, message):
+        if not bool(await is_admin(app, message)):
             await message.reply_text("🚫 <b>Only admins can do this.</b>", parse_mode=ParseMode.HTML)
             return None
         if not message.reply_to_message or not message.reply_to_message.from_user:
@@ -94,7 +92,7 @@ def register(app: Client) -> None:
     @app.on_message(filters.command("viewapproved") & filters.group)
     @catch_errors
     async def view_approved(client: Client, message: Message):
-        if not await is_admin(app, message):
+        if not bool(await is_admin(app, message)):
             await message.reply_text("🚫 <b>Only admins can view approvals.</b>", parse_mode=ParseMode.HTML)
             return
         users = await get_approved(message.chat.id)
@@ -107,7 +105,7 @@ def register(app: Client) -> None:
     @app.on_message(filters.command("approval") & filters.group)
     @catch_errors
     async def approval_mode_cmd(client: Client, message: Message):
-        if not await is_admin(app, message):
+        if not bool(await is_admin(app, message)):
             await message.reply_text("🔒 <b>Only admins can change approval mode.</b>", parse_mode=ParseMode.HTML)
             return
 
@@ -142,7 +140,7 @@ def register(app: Client) -> None:
         return None
 
     async def _require_admin(message: Message) -> bool:
-        if not await is_admin(app, message):
+        if not bool(await is_admin(app, message)):
             await message.reply_text("🔒 <b>Admins only.</b>", parse_mode=ParseMode.HTML)
             return False
         return True

--- a/oxeign/swagger/bots/bots_handlers/bots_callbacks.py
+++ b/oxeign/swagger/bots/bots_handlers/bots_callbacks.py
@@ -2,16 +2,14 @@ import logging
 from contextlib import suppress
 from time import perf_counter
 
-from pyrogram import Client, filters
+from pyrogram import Client
 from pyrogram.enums import ParseMode
 from pyrogram.types import CallbackQuery, InlineKeyboardMarkup, InlineKeyboardButton
 
 from config import SUPPORT_CHAT_URL, DEVELOPER_URL
 from utils.errors import catch_errors
-from utils.perms import is_admin
 from utils.messages import safe_edit_message
 from .panels import (
-    build_start_panel,
     get_help_keyboard,
     send_start,
 )
@@ -58,7 +56,6 @@ def register(app: Client) -> None:
     @catch_errors
     async def callback_handler(client: Client, query: CallbackQuery):
         data = query.data
-        chat_id = query.message.chat.id
 
         logger.debug("Callback triggered: %s", data)
 

--- a/oxeign/swagger/bots/bots_handlers/panels.py
+++ b/oxeign/swagger/bots/bots_handlers/panels.py
@@ -3,7 +3,6 @@ from html import escape
 from pyrogram.enums import ParseMode
 from pyrogram.types import Message, InlineKeyboardMarkup, InlineKeyboardButton
 
-from config import SUPPORT_CHAT_URL, DEVELOPER_URL
 from utils.perms import is_admin
 
 # Default image for all welcome messages
@@ -28,7 +27,7 @@ async def build_start_panel(is_admin: bool = False, *, include_back: bool = Fals
 async def send_start(client, message: Message, *, include_back: bool = False) -> None:
     bot_user = await client.get_me()
     user = message.from_user
-    markup = await build_start_panel(await is_admin(client, message), include_back=include_back)
+    markup = await build_start_panel(bool(await is_admin(client, message)), include_back=include_back)
 
     await message.reply_photo(
         photo=PANEL_IMAGE_URL,


### PR DESCRIPTION
## Summary
- clean up unused imports in admin handlers
- simplify callback handlers
- remove unused constants
- tighten boolean checks for admin lookups

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6868f0ed071c8329aff17e1c8e25ab27