### PR TITLE
Fix is_admin in private chats

### DIFF
--- a/utils/perms.py
+++ b/utils/perms.py
@@ -1,16 +1,20 @@
 from pyrogram import Client
 from pyrogram.types import Message, ChatMember
+from pyrogram.enums import ChatType
 
 async def is_admin(client: Client, message: Message, user_id: int = None) -> bool:
     """
     Checks whether the given user (or message sender) is an admin in the chat.
     Supports groups and supergroups.
     """
+    # Private chats have no admin concept
+    if message.chat.type == ChatType.PRIVATE:
+        return False
+
     try:
         chat_id = message.chat.id
         user_id = user_id or message.from_user.id
 
-        # Skip check if the user is the group creator (owner)
         member: ChatMember = await client.get_chat_member(chat_id, user_id)
         return member.status in ("administrator", "creator")
     except Exception as e:


### PR DESCRIPTION
## Summary
- prevent calling get_chat_member for private chats in `is_admin`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68693a6069d083298fb5149a71d438a6