### PR TITLE
Fix runtime broadcast handler import error

### DIFF
--- a/handlers/broadcast.py
+++ b/handlers/broadcast.py
@@ -1,7 +1,13 @@
 import asyncio
 import logging
 from pyrogram import Client, filters
-from pyrogram.errors import FloodWait, ChatWriteForbidden, PeerIdInvalid, UserIsBlocked, BotKicked
+from pyrogram.errors import (
+    FloodWait,
+    ChatWriteForbidden,
+    PeerIdInvalid,
+    UserIsBlocked,
+    UserKicked,
+)
 from pyrogram.enums import ParseMode
 from pyrogram.types import Message
 
@@ -45,9 +51,9 @@ def register(app: Client) -> None:
                     else:
                         await client.send_message(cid, payload_text, parse_mode=ParseMode.HTML)
                     sent += 1
-                except (ChatWriteForbidden, BotKicked, PeerIdInvalid, UserIsBlocked, Exception):
+                except (ChatWriteForbidden, UserKicked, PeerIdInvalid, UserIsBlocked, Exception):
                     failed += 1
-            except (ChatWriteForbidden, BotKicked, PeerIdInvalid, UserIsBlocked, Exception):
+            except (ChatWriteForbidden, UserKicked, PeerIdInvalid, UserIsBlocked, Exception):
                 failed += 1
             await asyncio.sleep(0.1)
         await message.reply_text(f"✅ Done. Sent: {sent}, Failed: {failed}")


### PR DESCRIPTION
## Summary
- replace `BotKicked` with `UserKicked`
- adjust error handling logic in broadcast handler

## Testing
- `python -m py_compile handlers/broadcast.py`
- `python - <<'PY'
import subprocess, sys, pathlib
files = [f.strip() for f in subprocess.check_output(['git','ls-files','*.py']).decode().splitlines()]
ret = 0
for f in files:
    try:
        compile(open(f,'rb').read(), f, 'exec')
    except Exception as e:
        print('Compile error in', f, e)
        ret = 1
sys.exit(ret)
PY
`

------
https://chatgpt.com/codex/tasks/task_b_68694944f5188329963c833e1080c026