### PR TITLE
Fix group commands and improve help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,28 @@ Use `/start` in private chat to see the welcome panel with:
 - **⚙️ Settings** – open the group control panel if used in a group.
 
 Use the provided commands to enable or disable features. Support and developer buttons open the URLs you set in `.env`.
+
+## 🚀 Deploying on Render
+
+1. Fork this repo and create a new **Background Worker** on [Render](https://render.com). You can use the provided `render.yaml` for one-click setup.
+2. Set the environment variables from `.env.example` in the Render dashboard.
+3. The worker command should run `sh start.sh` (same as the provided `Procfile`).
+4. Optionally deploy the included `web.py` as a separate web service for simple health checks.
+
+`render.yaml` already defines two services:
+
+```yaml
+services:
+  - type: worker
+    name: guard-bot
+    env: python
+    buildCommand: pip install -r requirements.txt
+    startCommand: python main.py
+  - type: web
+    name: guard-web
+    env: python
+    buildCommand: pip install -r requirements.txt
+    startCommand: python web.py
+```
+
+Deploy the worker and, if desired, the web service. No ports need to be exposed for the worker since it runs the Telegram bot in polling mode.

--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -16,7 +16,10 @@ logger = logging.getLogger(__name__)
 
 
 async def _require_admin_group(client: Client, message: Message) -> bool:
-    if message.chat.type not in {"group", "supergroup"}:
+    """Ensure the command is used by an admin inside a group."""
+    from pyrogram.enums import ChatType
+
+    if message.chat.type not in {ChatType.GROUP, ChatType.SUPERGROUP}:
         await message.reply_text("❗ Group-only command.")
         return False
     member = await client.get_chat_member(message.chat.id, message.from_user.id)

--- a/handlers/callbacks.py
+++ b/handlers/callbacks.py
@@ -12,10 +12,27 @@ from .panels import send_start, get_help_keyboard, build_settings_panel
 logger = logging.getLogger(__name__)
 
 help_sections = {
-    "help_biomode": "🛡️ <b>BioMode</b>\nDeletes messages from users whose bios contain links.",
-    "help_autodelete": "🧹 <b>AutoDelete</b>\nAutomatically deletes messages after a delay.",
-    "help_linkfilter": "🔗 <b>LinkFilter</b>\nBlocks non-admins from sending links.",
-    "help_editmode": "✏️ <b>EditMode</b>\nDeletes edited messages instantly.",
+    "help_biomode": (
+        "🛡️ <b>BioMode</b>\n"
+        "Enables scanning of user bios when they join. If the bio contains a link "
+        "or is unusually long, the join message is deleted and the user is warned.\n"
+        "Use <code>/biolink on|off</code> to toggle."
+    ),
+    "help_autodelete": (
+        "🧹 <b>AutoDelete</b>\n"
+        "Automatically removes all non-admin messages after the configured delay.\n"
+        "Set the delay with <code>/setautodelete &lt;seconds&gt;</code>. Use 0 to disable."
+    ),
+    "help_linkfilter": (
+        "🔗 <b>LinkFilter</b>\n"
+        "Deletes messages containing URLs from non-admin users. Useful against spam links.\n"
+        "Turn on or off with <code>/linkfilter on|off</code>."
+    ),
+    "help_editmode": (
+        "✏️ <b>EditMode</b>\n"
+        "Deletes edited messages from regular users. This prevents stealth editing of spam.\n"
+        "Toggle using <code>/editfilter on|off</code>."
+    ),
 }
 
 

--- a/handlers/general.py
+++ b/handlers/general.py
@@ -11,8 +11,11 @@ def register(app: Client) -> None:
 
     @app.on_message(filters.command("id"))
     async def id_cmd(client: Client, message: Message) -> None:
+        """Return chat and/or user IDs."""
+        from pyrogram.enums import ChatType
+
         target = message.reply_to_message.from_user if message.reply_to_message else message.from_user
-        if message.chat.type in {"group", "supergroup", "channel"}:
+        if message.chat.type in {ChatType.GROUP, ChatType.SUPERGROUP, ChatType.CHANNEL}:
             text = f"<b>Chat ID:</b> <code>{message.chat.id}</code>"
             if target:
                 text += f"\n<b>User ID:</b> <code>{target.id}</code>"


### PR DESCRIPTION
## Summary
- handle ChatType enums correctly in admin and general handlers
- expand inline help text with usage instructions
- document Render worker deployment steps

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6869524286948329b3d8f5ef4488c12f