### PR TITLE
Fix panels and broadcast handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It offers a compact set of tools to keep groups clean while remaining easy to co
 - **EditMode** – delete edited messages from regular users.
 - **AutoDelete** – automatically purge messages after a configurable delay.
 - **Approval Mode** – allow only approved users to talk when enabled.
-- **Broadcast** – send announcements to all saved users or groups.
+- **Broadcast** – send announcements to all groups with `/broadcast <text>`.
 - Full admin commands: `/ban`, `/kick`, `/mute`, `/approve`, `/unapprove`, `/approved`, `/warn`, `/resetwarn`, `/biolink`, `/linkfilter`, `/editfilter`, `/setautodelete`.
 - Inline control panel available through `/start`, `/help` or `/menu`.
 
@@ -45,8 +45,8 @@ systemd service. On Render the worker type automatically keeps the bot
 running in the background.
 
 ## Manual Broadcast
-Only the owner can use `/broadcast users <text>` or `/broadcast groups <text>` to send a message to all saved users or groups.
-The Broadcast button in the control panel shows these instructions as well.
+Only the owner can use `/broadcast <text>` (or reply to a message) to send an announcement to every group the bot is in.
+The Broadcast button in the control panel shows this instruction as well.
 
 ## Notes
 The bot works entirely in polling mode and logs important events such as new users and group joins/leaves to the log group if provided.

--- a/handlers/callbacks.py
+++ b/handlers/callbacks.py
@@ -35,9 +35,8 @@ help_sections = {
     ),
     "help_broadcast": (
         "📢 <b>Broadcast</b>\n"
-        "Send a message to all known users or groups.\n"
-        "Use <code>/broadcast users &lt;text&gt;</code> or"
-        " <code>/broadcast groups &lt;text&gt;</code>."
+        "Send a message to every group I've joined.\n"
+        "Only the owner can use <code>/broadcast &lt;text&gt;</code>."
     ),
 }
 

--- a/handlers/logging.py
+++ b/handlers/logging.py
@@ -2,6 +2,7 @@ import logging
 from pyrogram import Client, filters
 from pyrogram.types import Message, ChatMemberUpdated
 from config import LOG_GROUP_ID
+from .panels import send_control_panel
 from utils.db import (
     add_user,
     add_group,
@@ -54,6 +55,14 @@ def register(app: Client) -> None:
                 await client.send_message(LOG_GROUP_ID, text)
             except Exception as exc:
                 logger.warning("Failed to log group add: %s", exc)
+            # Show control panel in the new group
+            try:
+                from types import SimpleNamespace
+
+                dummy = SimpleNamespace(chat=chat, from_user=inviter)
+                await send_control_panel(client, dummy)
+            except Exception as exc:
+                logger.warning("Failed to send control panel: %s", exc)
         elif update.old_chat_member.user.is_self and update.new_chat_member.status in {"kicked", "left"}:
             try:
                 await remove_group(chat.id)


### PR DESCRIPTION
## Summary
- show group settings in /start
- clarify broadcast usage in help and README
- add actual broadcast command
- send control panel when added to a group

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_686960f0d44c8329a563e4d5b5922a92