### PR TITLE
Fix moderation features and add logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ It offers a compact set of tools to keep groups clean while remaining easy to co
 - **AutoDelete** – automatically purge messages after a configurable delay.
 - **Approval Mode** – allow only approved users to talk when enabled.
 - **Broadcast** – send announcements to all groups with `/broadcast <text>`.
-- Full admin commands: `/ban`, `/kick`, `/mute`, `/approve`, `/unapprove`, `/approved`, `/warn`, `/resetwarn`, `/biolink`, `/linkfilter`, `/editfilter`, `/setautodelete`.
 - Inline control panel available through `/start`, `/help` or `/menu`.
+
+## Commands
+`/ban`, `/kick`, `/mute`, `/warn`, `/resetwarn`, `/approve`, `/unapprove`, `/approved`, `/biolink`, `/linkfilter`, `/editfilter`, `/setautodelete`, `/broadcast` (owner only) and `/ping`.
 
 ## Requirements
 - Python 3.10+
@@ -25,10 +27,14 @@ It offers a compact set of tools to keep groups clean while remaining easy to co
    cd guard-bot
    pip install -r requirements.txt
    ```
-2. Copy `.env.example` to `.env` and fill in the variables:
+2. Copy `.env.example` to `.env` and fill in the variables.
+   Required variables are:
    - `API_ID`, `API_HASH`, `BOT_TOKEN`
-   - `MONGO_URI` and `MONGO_DB`
-   - optional: `OWNER_ID`, `SUPPORT_CHAT_URL`, `DEVELOPER_URL`, `LOG_GROUP_ID`
+   - `MONGO_URI`, `MONGO_DB`
+   Optional variables:
+   - `OWNER_ID` – your Telegram user ID for owner commands
+   - `LOG_GROUP_ID` – ID of a private channel for logs
+   - `SUPPORT_CHAT_URL`, `DEVELOPER_URL`, `PANEL_IMAGE_URL`
 3. Run the bot
    ```bash
    python3 main.py

--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -40,6 +40,7 @@ def register(app: Client) -> None:
             await message.reply_text("📌 Reply to a user")
             return
         user = message.reply_to_message.from_user
+        logger.debug("[ADMIN] %s on %s in chat %s", action, user.id, message.chat.id)
         try:
             if action == "ban":
                 await app.ban_chat_member(message.chat.id, user.id)
@@ -55,18 +56,22 @@ def register(app: Client) -> None:
 
     @app.on_message(filters.command("ban"))
     async def ban_cmd(_, message: Message):
+        logger.debug("[ADMIN] ban command by %s in %s", message.from_user.id, message.chat.id)
         await _admin_action(message, "ban")
 
     @app.on_message(filters.command("kick"))
     async def kick_cmd(_, message: Message):
+        logger.debug("[ADMIN] kick command by %s in %s", message.from_user.id, message.chat.id)
         await _admin_action(message, "kick")
 
     @app.on_message(filters.command("mute"))
     async def mute_cmd(_, message: Message):
+        logger.debug("[ADMIN] mute command by %s in %s", message.from_user.id, message.chat.id)
         await _admin_action(message, "mute")
 
     @app.on_message(filters.command("warn"))
     async def warn_cmd(_, message: Message):
+        logger.debug("[ADMIN] warn command by %s in %s", message.from_user.id, message.chat.id)
         if not await _require_admin_group(app, message):
             return
         if not message.reply_to_message or not message.reply_to_message.from_user:
@@ -83,6 +88,7 @@ def register(app: Client) -> None:
 
     @app.on_message(filters.command("resetwarn"))
     async def resetwarn_cmd(_, message: Message):
+        logger.debug("[ADMIN] resetwarn command by %s in %s", message.from_user.id, message.chat.id)
         if not await _require_admin_group(app, message):
             return
         if not message.reply_to_message or not message.reply_to_message.from_user:
@@ -101,6 +107,7 @@ def register(app: Client) -> None:
 
     @app.on_message(filters.command("biolink"))
     async def biolink_cmd(_, message: Message):
+        logger.debug("[ADMIN] biolink command by %s in %s", message.from_user.id, message.chat.id)
         if len(message.command) < 2:
             await message.reply_text("Usage: /biolink on|off")
             return
@@ -112,6 +119,7 @@ def register(app: Client) -> None:
 
     @app.on_message(filters.command("linkfilter"))
     async def linkfilter_cmd(_, message: Message):
+        logger.debug("[ADMIN] linkfilter command by %s in %s", message.from_user.id, message.chat.id)
         if len(message.command) < 2:
             await message.reply_text("Usage: /linkfilter on|off")
             return
@@ -120,6 +128,7 @@ def register(app: Client) -> None:
 
     @app.on_message(filters.command("editfilter"))
     async def editfilter_cmd(_, message: Message):
+        logger.debug("[ADMIN] editfilter command by %s in %s", message.from_user.id, message.chat.id)
         if len(message.command) < 2:
             await message.reply_text("Usage: /editfilter on|off")
             return
@@ -128,6 +137,7 @@ def register(app: Client) -> None:
 
     @app.on_message(filters.command("setautodelete"))
     async def set_autodelete_cmd(_, message: Message):
+        logger.debug("[ADMIN] setautodelete command by %s in %s", message.from_user.id, message.chat.id)
         if not await _require_admin_group(app, message):
             return
         seconds = 0
@@ -147,6 +157,7 @@ def register(app: Client) -> None:
 
     @app.on_message(filters.command("approve"))
     async def approve_cmd(_, message: Message):
+        logger.debug("[ADMIN] approve command by %s in %s", message.from_user.id, message.chat.id)
         if not await _require_admin_group(app, message):
             return
         if not message.reply_to_message or not message.reply_to_message.from_user:
@@ -158,6 +169,7 @@ def register(app: Client) -> None:
 
     @app.on_message(filters.command("unapprove"))
     async def unapprove_cmd(_, message: Message):
+        logger.debug("[ADMIN] unapprove command by %s in %s", message.from_user.id, message.chat.id)
         if not await _require_admin_group(app, message):
             return
         if not message.reply_to_message or not message.reply_to_message.from_user:
@@ -169,6 +181,7 @@ def register(app: Client) -> None:
 
     @app.on_message(filters.command("approved"))
     async def approved_cmd(_, message: Message):
+        logger.debug("[ADMIN] approved command by %s in %s", message.from_user.id, message.chat.id)
         if not await _require_admin_group(app, message):
             return
         users = await get_approved(message.chat.id)

--- a/handlers/broadcast.py
+++ b/handlers/broadcast.py
@@ -21,6 +21,7 @@ def register(app: Client) -> None:
     @app.on_message(filters.command("broadcast") & filters.user(OWNER_ID))
     async def broadcast_cmd(client: Client, message: Message) -> None:
         """Broadcast a message to all known groups."""
+        logger.debug("[BROADCAST] broadcast initiated by %s", message.from_user.id)
         if message.reply_to_message:
             payload_msg = message.reply_to_message
             text = None

--- a/handlers/callbacks.py
+++ b/handlers/callbacks.py
@@ -45,6 +45,7 @@ def register(app: Client) -> None:
     @app.on_callback_query()
     async def callbacks(client: Client, query: CallbackQuery):
         data = query.data
+        logger.debug("[CALLBACK] %s from %s in %s", data, query.from_user.id, query.message.chat.id)
         if data in {"cb_start", "cb_back_panel"}:
             await query.answer()
             await send_start(client, query.message, include_back=data == "cb_back_panel")

--- a/handlers/general.py
+++ b/handlers/general.py
@@ -1,18 +1,23 @@
+import logging
 from pyrogram import Client, filters
 from pyrogram.types import Message
 from pyrogram.enums import ParseMode
 from .panels import send_start
 
+logger = logging.getLogger(__name__)
+
 
 def register(app: Client) -> None:
     @app.on_message(filters.command(["start", "help", "menu", "panel"]))
     async def send_panel(client: Client, message: Message):
+        logger.debug("[GENERAL] panel command in chat %s", message.chat.id)
         await send_start(client, message)
 
     @app.on_message(filters.command("id"))
     async def id_cmd(client: Client, message: Message) -> None:
         """Return chat and/or user IDs."""
         from pyrogram.enums import ChatType
+        logger.debug("[GENERAL] id command in chat %s", message.chat.id)
 
         target = message.reply_to_message.from_user if message.reply_to_message else message.from_user
         if message.chat.type in {ChatType.GROUP, ChatType.SUPERGROUP, ChatType.CHANNEL}:
@@ -26,4 +31,5 @@ def register(app: Client) -> None:
     @app.on_message(filters.command("ping"))
     async def ping_cmd(client: Client, message: Message) -> None:
         """Simple health check command."""
+        logger.debug("[GENERAL] ping command in chat %s", message.chat.id)
         await message.reply_text("🏓 Pong!")

--- a/handlers/moderation.py
+++ b/handlers/moderation.py
@@ -68,6 +68,7 @@ def register(app: Client) -> None:
 
     @app.on_message(filters.group & ~filters.service)
     async def moderate_message(client: Client, message: Message) -> None:
+        logger.debug("[MODERATION] message from %s in %s", message.from_user.id if message.from_user else 'unknown', message.chat.id)
         if not message.from_user or message.from_user.is_bot:
             return
         if (await client.get_me()).id == message.from_user.id:
@@ -114,6 +115,7 @@ def register(app: Client) -> None:
 
     @app.on_edited_message(filters.group & ~filters.service)
     async def on_edit(client: Client, message: Message):
+        logger.debug("[MODERATION] edit event from %s in %s", message.from_user.id if message.from_user else 'unknown', message.chat.id)
         if not message.from_user or message.from_user.is_bot:
             return
         user = message.from_user
@@ -130,6 +132,7 @@ def register(app: Client) -> None:
 
     @app.on_message(filters.new_chat_members)
     async def check_new_member_bio(client: Client, message: Message):
+        logger.debug("[MODERATION] new member(s) in %s", message.chat.id)
         chat_id = message.chat.id
         bio_filter_enabled = await get_bio_filter(chat_id)
         if not bio_filter_enabled:

--- a/utils/db.py
+++ b/utils/db.py
@@ -1,6 +1,7 @@
 """Database helpers using Motor."""
 
 from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorDatabase
+from pymongo import ReturnDocument
 
 _client: AsyncIOMotorClient | None = None
 _db: AsyncIOMotorDatabase | None = None
@@ -81,7 +82,7 @@ async def increment_warning(chat_id: int, user_id: int) -> int:
         {"chat_id": chat_id, "user_id": user_id},
         {"$inc": {"count": 1}},
         upsert=True,
-        return_document=True,
+        return_document=ReturnDocument.AFTER,
     )
     return doc["count"]
 


### PR DESCRIPTION
## Summary
- fix ReturnDocument usage in database layer
- add debug logging to handlers for easier debugging
- show broadcast initiator in logs
- document commands and env vars

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_686966853050832987b3443c3236cc0a