### PR TITLE
Fix bot group handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,14 @@ It offers a compact set of tools to keep groups clean while remaining easy to co
    - `OWNER_ID` – your Telegram user ID for owner commands
    - `LOG_GROUP_ID` – ID of a private channel for logs
    - `SUPPORT_CHAT_URL`, `DEVELOPER_URL`, `PANEL_IMAGE_URL`
-3. Run the bot
+3. Run the bot locally for testing
    ```bash
    python3 main.py
    ```
    Keep it running using `screen`, `tmux` or a `systemd` service.
+
+4. To deploy on a server provide the same environment variables and execute
+   `sh start.sh`. The script simply runs `python main.py` with logging enabled.
 
 ## Render Deployment
 Create a new **Background Worker** on [Render](https://render.com) and use `render.yaml` for automatic configuration.
@@ -53,6 +56,10 @@ running in the background.
 ## Manual Broadcast
 Only the owner can use `/broadcast <text>` (or reply to a message) to send an announcement to every group the bot is in.
 The Broadcast button in the control panel shows this instruction as well.
+
+### Tips
+- Give the bot administrator rights in your groups so it can delete messages and manage users.
+- Use `/start` or `/menu` in a group as an admin to open the settings panel.
 
 ## Notes
 The bot works entirely in polling mode and logs important events such as new users and group joins/leaves to the log group if provided.

--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -1,6 +1,6 @@
-from . import admin, moderation, callbacks, logging, broadcast, general
+from . import admin, filters, callbacks, logging, broadcast, general
 
-MODULES = [admin, moderation, callbacks, logging, broadcast, general]
+MODULES = [admin, filters, callbacks, logging, broadcast, general]
 
 def register_all(app):
     for module in MODULES:

--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -2,6 +2,7 @@ import logging
 from pyrogram import Client, filters
 from pyrogram.types import Message, ChatPermissions
 from pyrogram.enums import ParseMode
+from utils.errors import catch_errors
 from utils.db import (
     approve_user,
     unapprove_user,
@@ -54,22 +55,26 @@ def register(app: Client) -> None:
             logger.error("%s failed: %s", action, exc)
             await message.reply_text(f"❌ Failed: {exc}")
 
-    @app.on_message(filters.command("ban"))
+    @app.on_message(filters.command("ban") & filters.group)
+    @catch_errors
     async def ban_cmd(_, message: Message):
         logger.debug("[ADMIN] ban command by %s in %s", message.from_user.id, message.chat.id)
         await _admin_action(message, "ban")
 
-    @app.on_message(filters.command("kick"))
+    @app.on_message(filters.command("kick") & filters.group)
+    @catch_errors
     async def kick_cmd(_, message: Message):
         logger.debug("[ADMIN] kick command by %s in %s", message.from_user.id, message.chat.id)
         await _admin_action(message, "kick")
 
-    @app.on_message(filters.command("mute"))
+    @app.on_message(filters.command("mute") & filters.group)
+    @catch_errors
     async def mute_cmd(_, message: Message):
         logger.debug("[ADMIN] mute command by %s in %s", message.from_user.id, message.chat.id)
         await _admin_action(message, "mute")
 
-    @app.on_message(filters.command("warn"))
+    @app.on_message(filters.command("warn") & filters.group)
+    @catch_errors
     async def warn_cmd(_, message: Message):
         logger.debug("[ADMIN] warn command by %s in %s", message.from_user.id, message.chat.id)
         if not await _require_admin_group(app, message):
@@ -86,7 +91,8 @@ def register(app: Client) -> None:
         else:
             await message.reply_text(f"⚠ Warned {user.mention}. ({count}/3)")
 
-    @app.on_message(filters.command("resetwarn"))
+    @app.on_message(filters.command("resetwarn") & filters.group)
+    @catch_errors
     async def resetwarn_cmd(_, message: Message):
         logger.debug("[ADMIN] resetwarn command by %s in %s", message.from_user.id, message.chat.id)
         if not await _require_admin_group(app, message):
@@ -105,7 +111,8 @@ def register(app: Client) -> None:
         state = "ENABLED ✅" if value == "1" else "DISABLED ❌"
         await message.reply_text(f"{label} {state}")
 
-    @app.on_message(filters.command("biolink"))
+    @app.on_message(filters.command("biolink") & filters.group)
+    @catch_errors
     async def biolink_cmd(_, message: Message):
         logger.debug("[ADMIN] biolink command by %s in %s", message.from_user.id, message.chat.id)
         if len(message.command) < 2:
@@ -117,7 +124,8 @@ def register(app: Client) -> None:
             f"🌐 Bio link filter {'ENABLED ✅' if state else 'DISABLED ❌'}"
         )
 
-    @app.on_message(filters.command("linkfilter"))
+    @app.on_message(filters.command("linkfilter") & filters.group)
+    @catch_errors
     async def linkfilter_cmd(_, message: Message):
         logger.debug("[ADMIN] linkfilter command by %s in %s", message.from_user.id, message.chat.id)
         if len(message.command) < 2:
@@ -126,7 +134,8 @@ def register(app: Client) -> None:
         state = message.command[1].lower() in {"on", "enable", "1", "true"}
         await _toggle_setting(message, "linkfilter", "1" if state else "0", "🔗 Link filter")
 
-    @app.on_message(filters.command("editfilter"))
+    @app.on_message(filters.command("editfilter") & filters.group)
+    @catch_errors
     async def editfilter_cmd(_, message: Message):
         logger.debug("[ADMIN] editfilter command by %s in %s", message.from_user.id, message.chat.id)
         if len(message.command) < 2:
@@ -135,7 +144,8 @@ def register(app: Client) -> None:
         state = message.command[1].lower() in {"on", "enable", "1", "true"}
         await _toggle_setting(message, "editmode", "1" if state else "0", "✏️ Edit filter")
 
-    @app.on_message(filters.command("setautodelete"))
+    @app.on_message(filters.command("setautodelete") & filters.group)
+    @catch_errors
     async def set_autodelete_cmd(_, message: Message):
         logger.debug("[ADMIN] setautodelete command by %s in %s", message.from_user.id, message.chat.id)
         if not await _require_admin_group(app, message):
@@ -155,7 +165,8 @@ def register(app: Client) -> None:
         else:
             await message.reply_text("🧹 Auto delete disabled")
 
-    @app.on_message(filters.command("approve"))
+    @app.on_message(filters.command("approve") & filters.group)
+    @catch_errors
     async def approve_cmd(_, message: Message):
         logger.debug("[ADMIN] approve command by %s in %s", message.from_user.id, message.chat.id)
         if not await _require_admin_group(app, message):
@@ -167,7 +178,8 @@ def register(app: Client) -> None:
         await approve_user(message.chat.id, user.id)
         await message.reply_text(f"✅ Approved {user.mention}")
 
-    @app.on_message(filters.command("unapprove"))
+    @app.on_message(filters.command("unapprove") & filters.group)
+    @catch_errors
     async def unapprove_cmd(_, message: Message):
         logger.debug("[ADMIN] unapprove command by %s in %s", message.from_user.id, message.chat.id)
         if not await _require_admin_group(app, message):
@@ -179,7 +191,8 @@ def register(app: Client) -> None:
         await unapprove_user(message.chat.id, user.id)
         await message.reply_text(f"❌ Unapproved {user.mention}")
 
-    @app.on_message(filters.command("approved"))
+    @app.on_message(filters.command("approved") & filters.group)
+    @catch_errors
     async def approved_cmd(_, message: Message):
         logger.debug("[ADMIN] approved command by %s in %s", message.from_user.id, message.chat.id)
         if not await _require_admin_group(app, message):

--- a/handlers/broadcast.py
+++ b/handlers/broadcast.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from pyrogram import Client, filters
+from utils.errors import catch_errors
 from pyrogram.errors import (
     FloodWait,
     ChatWriteForbidden,
@@ -19,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 def register(app: Client) -> None:
     @app.on_message(filters.command("broadcast") & filters.user(OWNER_ID))
+    @catch_errors
     async def broadcast_cmd(client: Client, message: Message) -> None:
         """Broadcast a message to all known groups."""
         logger.debug("[BROADCAST] broadcast initiated by %s", message.from_user.id)

--- a/handlers/callbacks.py
+++ b/handlers/callbacks.py
@@ -1,6 +1,7 @@
 import logging
 
 from pyrogram import Client, filters
+from utils.errors import catch_errors
 from pyrogram.enums import ParseMode
 from pyrogram.types import CallbackQuery, InlineKeyboardMarkup, InlineKeyboardButton
 
@@ -43,6 +44,7 @@ help_sections = {
 
 def register(app: Client) -> None:
     @app.on_callback_query()
+    @catch_errors
     async def callbacks(client: Client, query: CallbackQuery):
         data = query.data
         logger.debug("[CALLBACK] %s from %s in %s", data, query.from_user.id, query.message.chat.id)

--- a/handlers/filters.py
+++ b/handlers/filters.py
@@ -4,6 +4,7 @@ import re
 from contextlib import suppress
 
 from pyrogram import Client, filters
+from utils.errors import catch_errors
 from pyrogram.enums import ParseMode
 from pyrogram.types import Message, ChatPermissions, InlineKeyboardMarkup, InlineKeyboardButton
 
@@ -67,6 +68,7 @@ def register(app: Client) -> None:
         asyncio.create_task(delete_later(chat_id, msg_id, delay))
 
     @app.on_message(filters.group & ~filters.service)
+    @catch_errors
     async def moderate_message(client: Client, message: Message) -> None:
         logger.debug("[MODERATION] message from %s in %s", message.from_user.id if message.from_user else 'unknown', message.chat.id)
         if not message.from_user or message.from_user.is_bot:
@@ -114,6 +116,7 @@ def register(app: Client) -> None:
                     await message.reply_text(msg, reply_markup=kb, parse_mode=ParseMode.HTML, quote=True)
 
     @app.on_edited_message(filters.group & ~filters.service)
+    @catch_errors
     async def on_edit(client: Client, message: Message):
         logger.debug("[MODERATION] edit event from %s in %s", message.from_user.id if message.from_user else 'unknown', message.chat.id)
         if not message.from_user or message.from_user.is_bot:
@@ -131,6 +134,7 @@ def register(app: Client) -> None:
             await schedule_auto_delete(message.chat.id, message.id, fallback=0)
 
     @app.on_message(filters.new_chat_members)
+    @catch_errors
     async def check_new_member_bio(client: Client, message: Message):
         logger.debug("[MODERATION] new member(s) in %s", message.chat.id)
         chat_id = message.chat.id

--- a/handlers/general.py
+++ b/handlers/general.py
@@ -3,17 +3,20 @@ from pyrogram import Client, filters
 from pyrogram.types import Message
 from pyrogram.enums import ParseMode
 from .panels import send_start
+from utils.errors import catch_errors
 
 logger = logging.getLogger(__name__)
 
 
 def register(app: Client) -> None:
-    @app.on_message(filters.command(["start", "help", "menu", "panel"]))
+    @app.on_message(filters.command(["start", "help", "menu", "panel"]) & (filters.private | filters.group))
+    @catch_errors
     async def send_panel(client: Client, message: Message):
         logger.debug("[GENERAL] panel command in chat %s", message.chat.id)
         await send_start(client, message)
 
-    @app.on_message(filters.command("id"))
+    @app.on_message(filters.command("id") & (filters.private | filters.group))
+    @catch_errors
     async def id_cmd(client: Client, message: Message) -> None:
         """Return chat and/or user IDs."""
         from pyrogram.enums import ChatType
@@ -28,7 +31,8 @@ def register(app: Client) -> None:
             text = f"<b>Your ID:</b> <code>{target.id}</code>"
         await message.reply_text(text, parse_mode=ParseMode.HTML)
 
-    @app.on_message(filters.command("ping"))
+    @app.on_message(filters.command("ping") & (filters.private | filters.group))
+    @catch_errors
     async def ping_cmd(client: Client, message: Message) -> None:
         """Simple health check command."""
         logger.debug("[GENERAL] ping command in chat %s", message.chat.id)


### PR DESCRIPTION
## Summary
- rename moderation handlers to `filters` and use in initialization
- ensure general commands work in groups with error handling
- ensure all admin commands, callbacks and broadcast use catch_errors
- document deployment and admin tips in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68696bc9ed248329afb36036c23278ef