### PR TITLE
Fix missing filters import

### DIFF
--- a/oxeign/swagger/oxy/oxy_oxygenbot.py
+++ b/oxeign/swagger/oxy/oxy_oxygenbot.py
@@ -1,6 +1,6 @@
 import logging
 import asyncio
-from pyrogram import Client, idle
+from pyrogram import Client, filters, idle
 from pyrogram.enums import ParseMode
 from config import API_ID, API_HASH, BOT_TOKEN, MONGO_URI, MONGO_DB, LOG_LEVEL
 from handlers import register_all


### PR DESCRIPTION
## Summary
- add filters import for ping command

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68697cd9f0c48329ae9a3aa4d1b2d8b7