### PR TITLE
Restore bot entry file for deploy

### DIFF
--- a/oxygenbot.py
+++ b/oxygenbot.py
@@ -1,0 +1,5 @@
+from oxeign.swagger.oxy.oxy_oxygenbot import main
+import asyncio
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add missing `oxygenbot.py` entrypoint

## Testing
- `python3 -m py_compile oxygenbot.py`
- `find . -name '*.py' -print | xargs -I {} python3 -m py_compile {}`
- `python oxygenbot.py` *(fails: ModuleNotFoundError: No module named 'pyrogram')*

------
https://chatgpt.com/codex/tasks/task_b_686982c5137c832981a57f40f5e55024