### PR TITLE
Fix error imports

### DIFF
--- a/utils/errors.py
+++ b/utils/errors.py
@@ -1,1 +1,24 @@
-from oxeign.swagger.yard.yard_utils.yard_errors import CustomError, handle_error
+"""Utility functions for error handling used across the bot."""
+
+from __future__ import annotations
+
+import functools
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def catch_errors(func):
+    """Decorator that logs exceptions raised by async handlers."""
+
+    @functools.wraps(func)
+    async def wrapper(*args, **kwargs):
+        try:
+            return await func(*args, **kwargs)
+        except Exception:  # noqa: BLE001
+            logger.exception("Unhandled exception in %s", func.__name__)
+
+    return wrapper
+
+
+__all__ = ["catch_errors"]


### PR DESCRIPTION
## Summary
- implement `catch_errors` decorator in utils

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68698a29953c8329856b9a5697db1555