### PR TITLE
Fix duplicate handler registration logs

### DIFF
--- a/handlers/panels.py
+++ b/handlers/panels.py
@@ -12,7 +12,8 @@ from config import OWNER_ID
 PANEL_IMAGE_URL = os.getenv("PANEL_IMAGE_URL", "https://files.catbox.moe/uvqeln.jpg")
 
 def register(app: Client) -> None:
-    print("✅ Registered: panels.py")
+    """Register panel handlers (no runtime hooks required)."""
+    pass
 
 
 def mention_html(user_id: int, name: str) -> str:

--- a/mybot/handlers/admin.py
+++ b/mybot/handlers/admin.py
@@ -13,7 +13,6 @@ logger = logging.getLogger(__name__)
 
 
 def register(app: Client) -> None:
-    print("✅ Registered: admin.py")
 
     # Admin check
     async def _require_admin_group(client: Client, message: Message) -> bool:

--- a/mybot/handlers/broadcast.py
+++ b/mybot/handlers/broadcast.py
@@ -16,7 +16,6 @@ logger = logging.getLogger(__name__)
 
 
 def register(app: Client) -> None:
-    print("✅ Registered: broadcast.py")
 
     @app.on_message(filters.command("broadcast") & filters.user(OWNER_ID))
     @catch_errors

--- a/mybot/handlers/callbacks.py
+++ b/mybot/handlers/callbacks.py
@@ -43,7 +43,6 @@ help_sections = {
 
 
 def register(app: Client) -> None:
-    print("✅ Registered: callbacks.py")
 
     @app.on_callback_query()
     @catch_errors

--- a/mybot/handlers/filters.py
+++ b/mybot/handlers/filters.py
@@ -48,7 +48,6 @@ def build_warning(count: int, user, reason: str, is_final: bool = False):
 
 
 def register(app: Client) -> None:
-    print("✅ Registered: filters.py")
 
     edited_messages: set[tuple[int, int]] = set()
 

--- a/mybot/handlers/general.py
+++ b/mybot/handlers/general.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__)
 
 
 def register(app: Client) -> None:
-    print("✅ Registered: general.py")
 
     @app.on_message(filters.command(["start", "help", "menu", "panel"]) & (filters.private | filters.group))
     @catch_errors

--- a/mybot/handlers/logging.py
+++ b/mybot/handlers/logging.py
@@ -16,7 +16,6 @@ logger = logging.getLogger(__name__)
 
 
 def register(app: Client) -> None:
-    print("✅ Registered: logging.py")
 
     # Log private /start and store user
     @app.on_message(filters.command("start") & filters.private, group=-2)

--- a/mybot/handlers/panels.py
+++ b/mybot/handlers/panels.py
@@ -10,8 +10,8 @@ from ..config import OWNER_ID, PANEL_IMAGE_URL
 
 
 def register(app: Client) -> None:
-    print("✅ Registered: panels.py")
-
+    """Register panel handlers (no runtime hooks required)."""
+    pass
 
 def mention_html(user_id: int, name: str) -> str:
     """Safely mention a user in HTML format."""


### PR DESCRIPTION
## Summary
- remove extra `print` statements in handler modules so each file registers only once
- add docstring/pass for panel handler modules

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68698d7cecd08329b5f6c815bd3fff0f