### PR TITLE
Fix worker port issues

### DIFF
--- a/oxygenbot.py
+++ b/oxygenbot.py
@@ -1,5 +1,20 @@
-from mybot.main import main
+"""Entry point for the bot process."""
+
 import asyncio
+import threading
+from mybot.main import main
+import os
+from web import app as web_app
+
+
+def _start_web() -> None:
+    """Run the small Flask server used for platform health checks."""
+    port = int(os.environ.get("PORT", 10000))
+    web_app.run(host="0.0.0.0", port=port)
 
 if __name__ == "__main__":
+    # Run the lightweight Flask web server in a separate thread so platforms
+    # expecting an open port consider the service healthy.
+    thread = threading.Thread(target=_start_web, daemon=True)
+    thread.start()
     asyncio.run(main())


### PR DESCRIPTION
## Summary
- run a small Flask health server in a background thread so platforms detect an open port when the bot starts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68699fd2c2bc8329b5715822da1feaef