### PR TITLE
Fix missing Flask dependency

### DIFF
--- a/mybot/requirements.txt
+++ b/mybot/requirements.txt
@@ -2,3 +2,4 @@ pyrogram>=2.0.106
 motor>=3.4
 python-dotenv>=1.0.1
 tgcrypto>=1.2.5
+flask>=3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pyrogram>=2.0.106
 motor>=3.4
 python-dotenv>=1.0.1
 tgcrypto>=1.2.5
+flask>=3.0


### PR DESCRIPTION
## Summary
- install Flask by adding it to requirements

## Testing
- `pip install -r requirements.txt`
- `pip install -r mybot/requirements.txt`
- `python -m py_compile oxygenbot.py web.py mybot/main.py mybot/utils/*.py handlers/*.py mybot/handlers/*.py`


------
https://chatgpt.com/codex/tasks/task_b_6869a1c959e083299a01b2f94bc35ba4