### PR TITLE
Fix missing Telegram bot responses

### DIFF
--- a/mybot/main.py
+++ b/mybot/main.py
@@ -7,6 +7,7 @@ from .config import API_ID, API_HASH, BOT_TOKEN, MONGO_URI, MONGO_DB, LOG_LEVEL
 from .handlers import register_all
 from .utils.db import init_db, close_db
 from .utils.errors import catch_errors
+from .utils.webhook import delete_webhook
 
 logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
@@ -31,11 +32,7 @@ async def _ping(_, message):
 async def main() -> None:
     logger.info("🚀 Starting bot")
     await init_db(MONGO_URI, MONGO_DB)
-    try:
-        await bot.delete_webhook(drop_pending_updates=True)
-        logger.info("✅ Cleared any existing webhook")
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("Failed to delete webhook: %s", exc)
+    await delete_webhook(BOT_TOKEN)
     register_all(bot)
     async with bot:
         logger.info("🤖 Bot started and listening...")

--- a/mybot/utils/webhook.py
+++ b/mybot/utils/webhook.py
@@ -1,1 +1,7 @@
+"""Wrapper around webhook helper functions."""
+
 from oxeign.swagger.yard.yard_utils.yard_webhook import *  # noqa: F401,F403
+from ..utils.webhook import delete_webhook
+
+__all__ = [*globals().get("__all__", []), "delete_webhook"]
+

--- a/oxeign/swagger/oxy/oxy_main.py
+++ b/oxeign/swagger/oxy/oxy_main.py
@@ -5,6 +5,7 @@ from config import API_HASH, API_ID, BOT_TOKEN, MONGO_URI, MONGO_DB, LOG_LEVEL
 from handlers import register_all
 from utils.db import init_db, close_db
 from utils.errors import catch_errors
+from utils.webhook import delete_webhook
 
 # --- Logging Setup ---
 logging.basicConfig(
@@ -48,11 +49,7 @@ async def main():
     logger.info("🔌 Initializing MongoDB connection")
     await init_db(MONGO_URI, MONGO_DB)
 
-    try:
-        await bot.delete_webhook(drop_pending_updates=True)
-        logger.info("✅ Cleared any existing webhook")
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("Failed to delete webhook: %s", exc)
+    await delete_webhook(BOT_TOKEN)
 
     logger.info("⚙️ Registering all handlers")
     register_all(bot)

--- a/oxeign/swagger/oxy/oxy_oxygenbot.py
+++ b/oxeign/swagger/oxy/oxy_oxygenbot.py
@@ -5,6 +5,7 @@ from config import API_ID, API_HASH, BOT_TOKEN, MONGO_URI, MONGO_DB, LOG_LEVEL
 from handlers import register_all
 from utils.db import init_db, close_db
 from utils.errors import catch_errors
+from utils.webhook import delete_webhook
 
 logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
@@ -31,11 +32,7 @@ async def main():
     logger.info("🚀 Starting bot")
     await init_db(MONGO_URI, MONGO_DB)
 
-    try:
-        await bot.delete_webhook(drop_pending_updates=True)
-        logger.info("✅ Cleared any existing webhook")
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("Failed to delete webhook: %s", exc)
+    await delete_webhook(BOT_TOKEN)
     register_all(bot)
 
     async with bot:

--- a/utils/webhook.py
+++ b/utils/webhook.py
@@ -1,1 +1,33 @@
+"""Helper utilities for Telegram webhooks."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from urllib import request, parse, error
+
 from oxeign.swagger.yard.yard_utils.yard_webhook import *  # noqa: F401,F403
+
+logger = logging.getLogger(__name__)
+
+
+async def delete_webhook(bot_token: str) -> None:
+    """Remove the Telegram bot webhook via the HTTP Bot API."""
+    api_url = f"https://api.telegram.org/bot{bot_token}/deleteWebhook"
+    data = parse.urlencode({"drop_pending_updates": "true"}).encode("utf-8")
+    req = request.Request(api_url, data=data)
+
+    loop = asyncio.get_running_loop()
+
+    try:
+        logger.debug("Deleting webhook via Bot API")
+        await loop.run_in_executor(None, request.urlopen, req)
+        logger.info("✅ Webhook deleted")
+    except error.URLError as exc:
+        logger.error("❌ Failed to delete webhook: %s", exc.reason)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("🔥 Unexpected error while deleting webhook: %s", exc)
+
+
+__all__ = [*globals().get("__all__", []), "delete_webhook"]
+


### PR DESCRIPTION
## Summary
- provide webhook deletion utility
- remove invalid `bot.delete_webhook` calls and use new helper
- expose webhook helper in mybot utils

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_686a044355c48329ad626bce5a7c2e19