### PR TITLE
Fix startup error by avoiding circular import

### DIFF
--- a/mybot/utils/webhook.py
+++ b/mybot/utils/webhook.py
@@ -1,7 +1,9 @@
 """Wrapper around webhook helper functions."""
 
 from oxeign.swagger.yard.yard_utils.yard_webhook import *  # noqa: F401,F403
-from ..utils.webhook import delete_webhook
+# Import the helper from the top-level ``utils`` package, not from this
+# package itself, to avoid a circular import when ``mybot.utils`` is
+# initialised.
+from utils.webhook import delete_webhook
 
 __all__ = [*globals().get("__all__", []), "delete_webhook"]
-


### PR DESCRIPTION
## Summary
- avoid circular import in `mybot.utils.webhook`

## Testing
- `flake8 mybot/utils/webhook.py`
- `python -m compileall -q .`
- `python oxygenbot.py` *(fails: ModuleNotFoundError: No module named 'pyrogram')*

------
https://chatgpt.com/codex/tasks/task_b_686a0bddd0e88329beb0cf9b8e018573