### PR TITLE
Add fallback handlers for unmatched messages

### DIFF
--- a/handlers/general.py
+++ b/handlers/general.py
@@ -42,3 +42,20 @@ def register(app: Client) -> None:
     async def ping_cmd(client: Client, message: Message) -> None:
         logger.info("[GENERAL] ping command in chat %s", message.chat.id)
         await message.reply_text("🏓 Pong!")
+
+    @app.on_message(filters.private & ~filters.command(""))
+    @catch_errors
+    async def dm_fallback(client: Client, message: Message) -> None:
+        """Fallback for private chats when no command matched."""
+        print(f"[DM FALLBACK] {message.from_user.id}: {message.text}")
+        await message.reply_text(
+            "🤖 I received your message, but didn’t understand it."
+        )
+
+    @app.on_message(filters.group & ~filters.command("") & ~filters.service)
+    @catch_errors
+    async def group_fallback(client: Client, message: Message) -> None:
+        """Fallback for group chats when no command matched."""
+        print(
+            f"[GROUP FALLBACK] {message.chat.id}/{message.from_user.id}: {message.text}"
+        )

--- a/mybot/handlers/general.py
+++ b/mybot/handlers/general.py
@@ -41,3 +41,20 @@ def register(app: Client) -> None:
     async def ping_cmd(client: Client, message: Message) -> None:
         logger.info("[GENERAL] ping command in chat %s", message.chat.id)
         await message.reply_text("🏓 Pong!")
+
+    @app.on_message(filters.private & ~filters.command(""))
+    @catch_errors
+    async def dm_fallback(client: Client, message: Message) -> None:
+        """Fallback for private chats when no command matched."""
+        print(f"[DM FALLBACK] {message.from_user.id}: {message.text}")
+        await message.reply_text(
+            "🤖 I received your message, but didn’t understand it."
+        )
+
+    @app.on_message(filters.group & ~filters.command("") & ~filters.service)
+    @catch_errors
+    async def group_fallback(client: Client, message: Message) -> None:
+        """Fallback for group chats when no command matched."""
+        print(
+            f"[GROUP FALLBACK] {message.chat.id}/{message.from_user.id}: {message.text}"
+        )


### PR DESCRIPTION
## Summary
- handle unmatched DM messages
- log unmatched group messages without replies

## Testing
- `python -m py_compile handlers/general.py mybot/handlers/general.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686a15ce5d6083298bc86dbf3b21f744