### PR TITLE
Improve moderation commands and logging

### DIFF
--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -51,6 +51,21 @@ def register(app: Client) -> None:
                 await app.unban_chat_member(message.chat.id, user.id)
             elif action == "mute":
                 await app.restrict_chat_member(message.chat.id, user.id, ChatPermissions())
+            elif action == "unban":
+                await app.unban_chat_member(message.chat.id, user.id)
+            elif action == "unmute":
+                await app.restrict_chat_member(
+                    message.chat.id,
+                    user.id,
+                    ChatPermissions(
+                        can_send_messages=True,
+                        can_send_media_messages=True,
+                        can_send_polls=True,
+                        can_send_other_messages=True,
+                        can_add_web_page_previews=True,
+                        can_invite_users=True,
+                    ),
+                )
             await message.reply_text(f"{action.title()} successful ✅")
         except Exception as exc:
             logger.error("%s failed: %s", action, exc)
@@ -72,6 +87,16 @@ def register(app: Client) -> None:
     async def mute_cmd(_, message: Message):
         await _admin_action(message, "mute")
 
+    @app.on_message(filters.command("unban") & filters.group)
+    @catch_errors
+    async def unban_cmd(_, message: Message):
+        await _admin_action(message, "unban")
+
+    @app.on_message(filters.command("unmute") & filters.group)
+    @catch_errors
+    async def unmute_cmd(_, message: Message):
+        await _admin_action(message, "unmute")
+
     @app.on_message(filters.command("warn") & filters.group)
     @catch_errors
     async def warn_cmd(_, message: Message):
@@ -90,7 +115,7 @@ def register(app: Client) -> None:
         else:
             await message.reply_text(f"⚠ Warned {user.mention} ({count}/3)")
 
-    @app.on_message(filters.command("resetwarn") & filters.group)
+    @app.on_message(filters.command(["resetwarn", "rmwarn"]) & filters.group)
     @catch_errors
     async def resetwarn_cmd(_, message: Message):
         if not await _require_admin_group(app, message):

--- a/handlers/callbacks.py
+++ b/handlers/callbacks.py
@@ -35,6 +35,13 @@ help_sections = {
         "Deletes edited messages by normal users.\n"
         "Use <code>/editfilter on|off</code>."
     ),
+    "help_admin": (
+        "👮 <b>Admin Commands</b>\n"
+        "/ban, /unban - Ban or unban users\n"
+        "/kick - Kick users\n"
+        "/mute, /unmute - Restrict or allow talking\n"
+        "/warn - issue warning, /rmwarn - clear warnings",
+    ),
     "help_broadcast": (
         "📢 <b>Broadcast</b>\n"
         "Owner-only broadcast to groups via <code>/broadcast</code>."

--- a/handlers/logging_handler.py
+++ b/handlers/logging_handler.py
@@ -36,6 +36,13 @@ HELP_SECTIONS = {
         "Deletes edited messages by normal users.\n"
         "Use <code>/editfilter on|off</code>."
     ),
+    "help_admin": (
+        "👮 <b>Admin Commands</b>\n"
+        "/ban, /unban - Ban or unban users\n"
+        "/kick - Kick users\n"
+        "/mute, /unmute - Restrict or allow talking\n"
+        "/warn - issue warning, /rmwarn - clear warnings",
+    ),
     "help_broadcast": (
         "📢 <b>Broadcast</b>\n"
         "Owner-only broadcast to groups via <code>/broadcast</code>."


### PR DESCRIPTION
## Summary
- add `/unban` and `/unmute` commands
- allow `/rmwarn` as alias for `/resetwarn`
- log `/start` or panel use to the configured log group
- store users and groups when the panel is opened
- extend help menu with admin command info

## Testing
- `python -m py_compile handlers/admin.py handlers/panels.py handlers/callbacks.py handlers/logging_handler.py`


------
https://chatgpt.com/codex/tasks/task_b_686a3e418f58832983d002b09467ed9e