### PR TITLE
Fix handler registration

### DIFF
--- a/main.py
+++ b/main.py
@@ -40,8 +40,8 @@ async def main() -> None:
     await delete_webhook(BOT_TOKEN)
     logger.info("🔌 Webhook deleted (if any). Polling mode active.")
 
-    register_all(bot)
     async with bot:
+        register_all(bot)
         logger.info("🧩 Bot started. Handlers active.")
         await idle()
 

--- a/run.py
+++ b/run.py
@@ -33,8 +33,8 @@ async def main() -> None:
     await delete_webhook(BOT_TOKEN)
     logger.info("🔌 Webhook deleted (if any). Using polling mode.")
 
-    register_all(bot)
     async with bot:
+        register_all(bot)
         logger.info("🤖 Bot started. Waiting for events...")
         await idle()
 


### PR DESCRIPTION
## Summary
- ensure handlers are registered after the client starts

## Testing
- `python -m py_compile run.py main.py handlers/*.py utils/*.py`


------
https://chatgpt.com/codex/tasks/task_b_686a48b307d08329b59310c08f4edf60