### PR TITLE
Fix control panel and bio filter issues

### DIFF
--- a/handlers/filters.py
+++ b/handlers/filters.py
@@ -101,11 +101,13 @@ def register(app: Client) -> None:
                 return
 
             if needs_filtering and await get_bio_filter(chat_id):
-                try:
-                    user_info = await client.get_chat(user.id)
-                    bio = getattr(user_info, "bio", "")
-                except Exception:
-                    bio = ""
+                bio = getattr(user, "bio", "")
+                if not bio:
+                    try:
+                        user_info = await client.get_chat(user.id)
+                        bio = getattr(user_info, "bio", "")
+                    except Exception:
+                        bio = ""
 
                 if bio and (len(bio) > MAX_BIO_LENGTH or contains_link(bio)):
                     logger.debug("[FILTER] Bio violation for %s in %s", user.id, chat_id)
@@ -156,11 +158,13 @@ def register(app: Client) -> None:
             if await is_admin(client, message, user.id) or await is_approved(chat_id, user.id):
                 continue
 
-            try:
-                user_info = await client.get_chat(user.id)
-                bio = getattr(user_info, "bio", "")
-            except Exception:
-                continue
+            bio = getattr(user, "bio", "")
+            if not bio:
+                try:
+                    user_info = await client.get_chat(user.id)
+                    bio = getattr(user_info, "bio", "")
+                except Exception:
+                    continue
 
             if bio and (len(bio) > MAX_BIO_LENGTH or contains_link(bio)):
                 logger.debug("[FILTER] New member bio violation %s in %s", user.id, chat_id)

--- a/handlers/panels.py
+++ b/handlers/panels.py
@@ -65,10 +65,14 @@ async def send_start(client: Client, message: Message, *, include_back: bool = F
     is_owner = user.id == OWNER_ID
 
     if chat.type in {ChatType.GROUP, ChatType.SUPERGROUP}:
+        # Always track the group so broadcast works even if a non-admin
+        # triggers the start command.
+        await add_group(chat.id)
+
         if not await is_admin(client, message):
             await message.reply_text("🔒 Only admins can view the control panel.")
             return
-        await add_group(chat.id)
+
         markup = await build_settings_panel(chat.id)
         caption = "⚙️ <b>Group Settings</b>"
     else:


### PR DESCRIPTION
## Summary
- ensure groups are tracked even when `/start` is run by non-admins
- improve bio link filter by checking existing user info before API call

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_b_686a8b43a15c832981e9bf7b9ebc180e