### PR TITLE
Improve broadcast tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ running in the background.
    Detach with `Ctrl+A` then `D`. Reattach with `screen -r oxygen`.
 
 ## Manual Broadcast
-Only the owner can use `/broadcast <text>` (or reply to a message) to send an announcement to every group the bot is in.
+Only the owner can use `/broadcast <text>` (or reply to a message) to send an announcement.
+Messages are delivered to all groups and private users that have interacted with the bot.
 The Broadcast button in the control panel shows this instruction as well.
 
 ### Tips

--- a/handlers/broadcast.py
+++ b/handlers/broadcast.py
@@ -9,7 +9,10 @@ from pyrogram.errors import (
 )
 
 from config import OWNER_ID
-from utils.db import get_groups
+from utils.db import (
+    get_broadcast_groups,
+    get_broadcast_users,
+)
 from utils.errors import catch_errors
 
 logger = logging.getLogger(__name__)
@@ -36,11 +39,16 @@ def register(app: Client) -> None:
             await message.reply_text("❗ Usage:\nReply to a message or use `/broadcast <text>`")
             return
 
-        group_ids = await get_groups()
-        logger.debug("[BROADCAST] Sending to %d groups", len(group_ids))
+        groups = await get_broadcast_groups()
+        users = await get_broadcast_users()
+        targets = set(groups + users)
+        logger.debug(
+            "[BROADCAST] Sending to %d chats (%d groups, %d users)",
+            len(targets), len(groups), len(users)
+        )
         sent, failed = 0, 0
 
-        for chat_id in group_ids:
+        for chat_id in targets:
             try:
                 if payload_msg:
                     await payload_msg.copy(chat_id)

--- a/handlers/general.py
+++ b/handlers/general.py
@@ -75,8 +75,9 @@ def register(app: Client) -> None:
     async def track_bot_added(client: Client, message: Message):
         me = await client.get_me()
         if any(m.id == me.id for m in message.new_chat_members):
-            from utils.db import add_group
+            from utils.db import add_group, add_broadcast_group
             await add_group(message.chat.id)
+            await add_broadcast_group(message.chat.id)
             logger.info("[GENERAL] Bot added to group %s", message.chat.id)
 
     @app.on_message(filters.left_chat_member & filters.group)
@@ -84,6 +85,7 @@ def register(app: Client) -> None:
     async def track_bot_left(client: Client, message: Message):
         me = await client.get_me()
         if message.left_chat_member and message.left_chat_member.id == me.id:
-            from utils.db import remove_group
+            from utils.db import remove_group, remove_broadcast_group
             await remove_group(message.chat.id)
+            await remove_broadcast_group(message.chat.id)
             logger.info("[GENERAL] Bot removed from group %s", message.chat.id)

--- a/handlers/panels.py
+++ b/handlers/panels.py
@@ -11,6 +11,8 @@ from utils.db import (
     get_bio_filter,
     add_group,
     add_user,
+    add_broadcast_group,
+    add_broadcast_user,
 )
 from utils.errors import catch_errors
 from utils.messages import safe_edit_message
@@ -68,6 +70,7 @@ async def send_start(client: Client, message: Message, *, include_back: bool = F
         # Always track the group so broadcast works even if a non-admin
         # triggers the start command.
         await add_group(chat.id)
+        await add_broadcast_group(chat.id)
 
         if not await is_admin(client, message):
             await message.reply_text("🔒 Only admins can view the control panel.")
@@ -82,6 +85,7 @@ async def send_start(client: Client, message: Message, *, include_back: bool = F
             include_back=include_back,
         )
         await add_user(user.id)
+        await add_broadcast_user(user.id)
         caption = (
             f"🎉 <b>Welcome to {bot_user.first_name}</b>\n\n"
             f"Hello {mention_html(user.id, user.first_name)}!\n\n"


### PR DESCRIPTION
## Summary
- record broadcast users/groups when the panel is opened
- broadcast to both stored groups and users
- maintain broadcast list when bot is added or removed
- document broadcast behaviour in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_686a8e7402808329b07a520188bf952b