### PR TITLE
Fix panel callbacks and BioLink filtering

### DIFF
--- a/handlers/filters.py
+++ b/handlers/filters.py
@@ -18,7 +18,7 @@ from utils.perms import is_admin
 logger = logging.getLogger(__name__)
 
 LINK_RE = re.compile(
-    r"(?:https?://\S+|tg://\S+|t\.me/\S+|telegram\.me/\S+|(?:\w+\.)+\w{2,})",
+    r"(?:https?://\S+|tg://\S+|t\.me/\S+|telegram\.me/\S+|(?:[A-Za-z0-9-]+\.)+[A-Za-z]{2,})",
     re.IGNORECASE,
 )
 MAX_BIO_LENGTH = 800
@@ -68,7 +68,7 @@ def register(app: Client) -> None:
             asyncio.create_task(delete_later(chat_id, msg_id, delay))
 
     # Main message moderation
-    @app.on_message(filters.group & ~filters.service)
+    @app.on_message(filters.group & ~filters.service, group=1)
     @catch_errors
     async def moderate_message(client: Client, message: Message) -> None:
         if not message.from_user or message.from_user.is_bot:
@@ -125,7 +125,7 @@ def register(app: Client) -> None:
         await message.reply_text(msg, parse_mode=ParseMode.HTML, quote=True)
 
     # Edited message check
-    @app.on_edited_message(filters.group & ~filters.service)
+    @app.on_edited_message(filters.group & ~filters.service, group=1)
     @catch_errors
     async def on_edit(client: Client, message: Message):
         if not message.from_user or message.from_user.is_bot:
@@ -145,7 +145,7 @@ def register(app: Client) -> None:
             await schedule_auto_delete(chat_id, message.id, fallback=0)
 
     # New user bio check
-    @app.on_message(filters.new_chat_members)
+    @app.on_message(filters.new_chat_members & filters.group, group=1)
     @catch_errors
     async def check_new_member_bio(client: Client, message: Message):
         chat_id = message.chat.id

--- a/handlers/logging_handler.py
+++ b/handlers/logging_handler.py
@@ -10,7 +10,12 @@ from utils.db import (
     get_setting, set_setting
 )
 from utils.messages import safe_edit_message
-from handlers.panels import send_start, get_help_keyboard, build_settings_panel
+from handlers.panels import (
+    send_start,
+    get_help_keyboard,
+    build_settings_panel,
+    render_settings_panel,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -66,14 +71,10 @@ def register(app: Client) -> None:
             await query.answer()
             await send_start(client, query.message, include_back=(data == "cb_back_panel"))
 
-        elif data == "open_settings":
-            await query.answer()
-            await _render_settings_panel(query)
-
         elif data.startswith("toggle_"):
             await query.answer("Toggled ✅")
             await _handle_toggle(data, query.message.chat.id)
-            await _render_settings_panel(query)
+            await render_settings_panel(client, query.message)
 
         elif data in {"cb_help_start", "cb_help_panel"}:
             await query.answer()
@@ -122,16 +123,6 @@ def register(app: Client) -> None:
             await query.answer("⚠️ Unknown action", show_alert=True)
 
 
-# 🔁 Update the group settings panel
-async def _render_settings_panel(query: CallbackQuery):
-    chat_id = query.message.chat.id
-    markup = await build_settings_panel(chat_id)
-    await safe_edit_message(
-        query.message,
-        caption="⚙️ <b>Group Settings</b>",
-        reply_markup=markup,
-        parse_mode=ParseMode.HTML,
-    )
 
 
 # ⚙️ Toggle settings and update DB

--- a/handlers/panels.py
+++ b/handlers/panels.py
@@ -134,6 +134,18 @@ def get_help_keyboard(back_cb: str) -> InlineKeyboardMarkup:
     ])
 
 
+# 🔁 Render group settings panel for a message or callback
+async def render_settings_panel(client: Client, message: Message) -> None:
+    chat_id = message.chat.id
+    markup = await build_settings_panel(chat_id)
+    await safe_edit_message(
+        message,
+        caption="⚙️ <b>Group Settings</b>",
+        reply_markup=markup,
+        parse_mode=ParseMode.HTML,
+    )
+
+
 # 📦 Register handlers
 def register(app: Client) -> None:
     logger.info("✅ Registered: panels.py")
@@ -142,6 +154,12 @@ def register(app: Client) -> None:
     @app.on_message(filters.command("menu") & filters.group)
     async def show_menu(client: Client, message: Message):
         await send_control_panel(client, message)
+
+    # ⚙️ Open settings via inline button
+    @app.on_callback_query(filters.regex("^open_settings$"))
+    async def open_settings_cb(client: Client, query: CallbackQuery):
+        await render_settings_panel(client, query.message)
+        await query.answer()
 
     # ⏪ Back to Main Panel
     @app.on_callback_query(filters.regex("^(cb_start|cb_back_panel)$"))


### PR DESCRIPTION
## Summary
- ensure filtering handlers run after command handlers
- add settings callback handler and reusable render helper
- simplify logging handler callbacks
- improve link regex detection

## Testing
- `python -m pip install -q -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686a9faa8e088329bebbb57f704b2701