### PR TITLE
Fix panel and logging, improve BioLink filter

### DIFF
--- a/handlers/logging_handler.py
+++ b/handlers/logging_handler.py
@@ -69,7 +69,12 @@ def register(app: Client) -> None:
 
         if data in {"cb_start", "cb_back_panel"}:
             await query.answer()
-            await send_start(client, query.message, include_back=(data == "cb_back_panel"))
+            await send_start(
+                client,
+                query.message,
+                include_back=(data == "cb_back_panel"),
+                log_panel=False,
+            )
 
         elif data.startswith("toggle_"):
             await query.answer("Toggled ✅")


### PR DESCRIPTION
## Summary
- show the full control panel in groups just like in DM
- log only `/start` in DM or when the bot joins/leaves a group
- stop logging when users open inline panels
- improve BioLink filter detection logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_686aa4851a0083298f017d4199e32784