### PR TITLE
Fix callback routing and bio filter

### DIFF
--- a/handlers/filters.py
+++ b/handlers/filters.py
@@ -21,7 +21,8 @@ LINK_RE = re.compile(
     r"(?:https?://\S+|tg://\S+|t\.me/\S+|telegram\.me/\S+|(?:[A-Za-z0-9-]+\.)+[A-Za-z]{2,})",
     re.IGNORECASE,
 )
-MAX_BIO_LENGTH = 800
+# Bios longer than Telegram's official 70 character limit are considered spammy
+MAX_BIO_LENGTH = 70
 
 
 def contains_link(text: str) -> bool:

--- a/handlers/logging_handler.py
+++ b/handlers/logging_handler.py
@@ -58,7 +58,7 @@ HELP_SECTIONS = {
 def register(app: Client) -> None:
     logger.info("✅ Registered: logging_handler.py")
 
-    @app.on_callback_query()
+    @app.on_callback_query(group=1)
     @catch_errors
     async def handle_callback(client: Client, query: CallbackQuery):
         data = query.data
@@ -75,6 +75,10 @@ def register(app: Client) -> None:
                 include_back=(data == "cb_back_panel"),
                 log_panel=False,
             )
+
+        elif data == "open_settings":
+            await query.answer()
+            await render_settings_panel(client, query.message)
 
         elif data.startswith("toggle_"):
             await query.answer("Toggled ✅")

--- a/handlers/panels.py
+++ b/handlers/panels.py
@@ -159,34 +159,3 @@ def register(app: Client) -> None:
     async def show_menu(client: Client, message: Message):
         await send_control_panel(client, message)
 
-    # ⚙️ Open settings via inline button
-    @app.on_callback_query(filters.regex("^open_settings$"))
-    async def open_settings_cb(client: Client, query: CallbackQuery):
-        await render_settings_panel(client, query.message)
-        await query.answer()
-
-    # ⏪ Back to Main Panel
-    @app.on_callback_query(filters.regex("^(cb_start|cb_back_panel)$"))
-    async def back_to_main(client: Client, query: CallbackQuery):
-        user = query.from_user
-        is_owner = user.id == OWNER_ID
-        is_admin_ = await is_admin(client, query.message)
-        markup = await build_start_panel(is_admin_, is_owner=is_owner)
-        await query.message.edit_caption(
-            caption=query.message.caption or "🎛 Main Panel",
-            reply_markup=markup,
-            parse_mode=ParseMode.HTML
-        )
-        await query.answer()
-
-    # 📘 Help Panel
-    @app.on_callback_query(filters.regex("^cb_help_start$"))
-    @catch_errors
-    async def open_help(client: Client, query: CallbackQuery):
-        await safe_edit_message(
-            query.message,
-            caption="📘 <b>Command Help</b>\n\nUse the buttons below to learn more.",
-            reply_markup=get_help_keyboard("cb_start"),
-            parse_mode=ParseMode.HTML,
-        )
-        await query.answer()


### PR DESCRIPTION
## Summary
- clean up duplicate panel callbacks
- centralize callback handling with `open_settings`
- shorten bio length threshold for the BioLink filter

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_686aaaa4dfec8329be468e9211c233dd