### PR TITLE
Fix bio filter and panel permissions

### DIFF
--- a/handlers/filters.py
+++ b/handlers/filters.py
@@ -21,8 +21,6 @@ LINK_RE = re.compile(
     r"(?:https?://\S+|tg://\S+|t\.me/\S+|telegram\.me/\S+|(?:[A-Za-z0-9-]+\.)+[A-Za-z]{2,})",
     re.IGNORECASE,
 )
-# Bios longer than Telegram's official 70 character limit are considered spammy
-MAX_BIO_LENGTH = 4
 
 
 def contains_link(text: str) -> bool:
@@ -102,14 +100,14 @@ def register(app: Client) -> None:
                 except Exception:
                     bio = ""
 
-            if bio and (len(bio) > MAX_BIO_LENGTH or contains_link(bio)):
+            if bio and contains_link(bio):
                 logger.debug("[FILTER] Bio violation for %s in %s", user.id, chat_id)
                 await handle_violation(
                     client,
                     message,
                     user,
                     chat_id,
-                    "Your bio contains a link or is too long, which is not allowed.",
+                    "Your bio contains a link, which is not allowed.",
                 )
                 return
 
@@ -172,12 +170,12 @@ def register(app: Client) -> None:
                 except Exception:
                     continue
 
-            if bio and (len(bio) > MAX_BIO_LENGTH or contains_link(bio)):
+            if bio and contains_link(bio):
                 logger.debug("[FILTER] New member bio violation %s in %s", user.id, chat_id)
                 await suppress_delete(message)
                 count = await increment_warning(chat_id, user.id)
                 if count >= 3:
                     await client.restrict_chat_member(chat_id, user.id, ChatPermissions())
                     await reset_warning(chat_id, user.id)
-                msg, _ = build_warning(count, user, "Your bio contains a link or is too long, which is not allowed.", is_final=(count >= 3))
+                msg, _ = build_warning(count, user, "Your bio contains a link, which is not allowed.", is_final=(count >= 3))
                 await message.reply_text(msg, parse_mode=ParseMode.HTML, quote=True)

--- a/handlers/logging_handler.py
+++ b/handlers/logging_handler.py
@@ -10,6 +10,7 @@ from utils.db import (
     get_setting, set_setting
 )
 from utils.messages import safe_edit_message
+from utils.perms import is_admin
 from handlers.panels import (
     send_start,
     get_help_keyboard,
@@ -79,11 +80,16 @@ def register(app: Client) -> None:
         elif data == "open_settings":
             await query.answer()
             await render_settings_panel(client, query.message)
+            if not await is_admin(client, query.message, user_id):
+                await query.answer("Read-only view", show_alert=False)
 
         elif data.startswith("toggle_"):
-            await query.answer("Toggled ✅")
-            await _handle_toggle(data, query.message.chat.id)
-            await render_settings_panel(client, query.message)
+            if await is_admin(client, query.message, user_id):
+                await query.answer("Toggled ✅")
+                await _handle_toggle(data, query.message.chat.id)
+                await render_settings_panel(client, query.message)
+            else:
+                await query.answer("Admins only", show_alert=True)
 
         elif data in {"cb_help_start", "cb_help_panel"}:
             await query.answer()

--- a/handlers/panels.py
+++ b/handlers/panels.py
@@ -30,8 +30,8 @@ def mention_html(user_id: int, name: str) -> str:
 # 🔘 Start Panel (DM)
 async def build_start_panel(is_admin: bool = False, *, is_owner: bool = False, include_back: bool = False) -> InlineKeyboardMarkup:
     buttons = [[InlineKeyboardButton("📘 Commands", callback_data="cb_help_start")]]
-    if is_admin:
-        buttons.insert(0, [InlineKeyboardButton("⚙️ Settings", callback_data="open_settings")])
+    # Show settings button to everyone so non-admins can view the panel too
+    buttons.insert(0, [InlineKeyboardButton("⚙️ Settings", callback_data="open_settings")])
     if is_owner:
         buttons.append([InlineKeyboardButton("📢 Broadcast", callback_data="help_broadcast")])
     if include_back:
@@ -78,10 +78,6 @@ async def send_start(
         # Always track the group so broadcast works even if a non-admin
         await add_group(chat.id)
         await add_broadcast_group(chat.id)
-
-        if not is_admin_user:
-            await message.reply_text("🔒 Only admins can view the control panel.")
-            return
     else:
         await add_user(user.id)
         await add_broadcast_user(user.id)
@@ -98,6 +94,9 @@ async def send_start(
         "Use the buttons below to access features and controls.\n\n"
         "✅ Group-ready\n🛠 Admin settings\n🧠 Smart moderation tools"
     )
+
+    if chat.type in {ChatType.GROUP, ChatType.SUPERGROUP} and not is_admin_user:
+        caption += "\n\n<em>Settings are read-only for non-admins.</em>"
 
     await message.reply_photo(
         photo=PANEL_IMAGE_URL,

--- a/utils/perms.py
+++ b/utils/perms.py
@@ -2,6 +2,7 @@
 
 import logging
 from pyrogram import Client
+from config import OWNER_ID
 from pyrogram.types import Message, ChatMember
 from pyrogram.enums import ChatType, ChatMemberStatus
 
@@ -21,6 +22,9 @@ async def is_admin(client: Client, message: Message, user_id: int | None = None)
         if uid is None:
             logger.debug("No user_id available for admin check in chat %s", chat_id)
             return False
+
+        if uid == OWNER_ID:
+            return True
 
         member: ChatMember = await client.get_chat_member(chat_id, uid)
         return member.status in {


### PR DESCRIPTION
## Summary
- allow non-admins to open the group control panel in `/start`, `/help`, and `/menu`
- clarify that settings are read-only for non-admins
- restrict toggle callbacks to admins
- treat OWNER_ID as admin in permission checks
- simplify bio link filter to scan on every message

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_686aaedadc208329b3f1238215b661e9