### PR TITLE
Fix biolink filter and admin callback

### DIFF
--- a/handlers/logging_handler.py
+++ b/handlers/logging_handler.py
@@ -100,6 +100,15 @@ def register(app: Client) -> None:
                 parse_mode=ParseMode.HTML,
             )
 
+        elif data == "help_admin":
+            await query.answer()
+            await safe_edit_message(
+                query.message,
+                caption=HELP_SECTIONS.get("help_admin", ""),
+                reply_markup=get_help_keyboard("cb_help_start"),
+                parse_mode=ParseMode.HTML,
+            )
+
         elif data in HELP_SECTIONS:
             await query.answer()
             await safe_edit_message(


### PR DESCRIPTION
## Summary
- ensure autodelete runs only after other checks to avoid duplicate deletions
- handle Admin help callback properly
- verify bio link check helper

## Testing
- `python -m py_compile handlers/*.py utils/*.py main.py run.py`
- `pip install -q -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_b_686ab44a3cc883299382dc837ae7ac4f