### PR TITLE
Fix bio link filter and admin help callback

### DIFF
--- a/handlers/filters.py
+++ b/handlers/filters.py
@@ -36,15 +36,12 @@ async def suppress_delete(message: Message):
 
 
 async def get_user_bio(client: Client, user) -> str:
-    """Return the user's bio, fetching it if necessary."""
-    bio = getattr(user, "bio", "")
-    if not bio:
-        try:
-            user_info = await client.get_chat(user.id)
-            bio = getattr(user_info, "bio", "")
-        except Exception:
-            bio = ""
-    return bio
+    """Return the user's bio, always fetching the latest from Telegram."""
+    try:
+        user_info = await client.get_chat(user.id)
+        return getattr(user_info, "bio", "") or ""
+    except Exception:
+        return ""
 
 
 async def bio_link_violation(

--- a/handlers/logging_handler.py
+++ b/handlers/logging_handler.py
@@ -47,7 +47,7 @@ HELP_SECTIONS = {
         "/ban, /unban - Ban or unban users\n"
         "/kick - Kick users\n"
         "/mute, /unmute - Restrict or allow talking\n"
-        "/warn - issue warning, /rmwarn - clear warnings",
+        "/warn - issue warning, /rmwarn - clear warnings"
     ),
     "help_broadcast": (
         "📢 <b>Broadcast</b>\n"


### PR DESCRIPTION
## Summary
- ensure user bios are always refreshed from Telegram
- make Admin help callback work (string value not tuple)

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_686abad05e3c8329bf34212c34673e7f