### PR TITLE
Fix biolink filter check order

### DIFF
--- a/handlers/filters.py
+++ b/handlers/filters.py
@@ -115,13 +115,14 @@ def register(app: Client) -> None:
         is_approved_user = await is_approved(chat_id, user.id)
         needs_filtering = not is_admin_user and not is_approved_user
 
+        # Bio link check runs first so violations are always caught
+        if needs_filtering and await bio_link_violation(client, message, user, chat_id):
+            return
+
         # Approval block
         if needs_filtering and await get_approval_mode(chat_id):
             await suppress_delete(message)
             await message.reply_text("❌ You are not approved to speak here.", quote=True)
-            return
-
-        if needs_filtering and await bio_link_violation(client, message, user, chat_id):
             return
 
         # Content filters


### PR DESCRIPTION
## Summary
- ensure bio link check always runs when a user sends a message

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686ac2747c9c832987d8fb0db2ec8186