### PR TITLE
Fix bio filter retrieval

### DIFF
--- a/utils/db.py
+++ b/utils/db.py
@@ -31,8 +31,11 @@ async def set_setting(chat_id: int, key: str, value: str) -> None:
 
 # ------------------ BIO FILTER ------------------ #
 async def get_bio_filter(chat_id: int) -> bool:
+    """Return True if the bio link filter is enabled for the chat."""
     value = await get_setting(chat_id, "biofilter", "0")
-    return value == "1"
+    if isinstance(value, bool):
+        return value
+    return str(value).lower() in {"1", "true", "on", "yes"}
 
 
 async def set_bio_filter(chat_id: int, enabled: bool) -> None:


### PR DESCRIPTION
## Summary
- interpret any truthy value for biofilter setting so `get_bio_filter` works even if DB contains non-string values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686adedc4a088329895eb38c1f635bd2